### PR TITLE
fix: empty password check

### DIFF
--- a/config.go
+++ b/config.go
@@ -132,7 +132,7 @@ func (cfg *Config) SetUpdate(key string, value string, encryptionKey string) {
 func (cfg *Config) CheckUnlockPassword(encryptionKey string) bool {
 	decryptedValue, err := cfg.Get("UnlockPasswordCheck", encryptionKey)
 
-	return err == nil && decryptedValue == UnlockPasswordCheck
+	return err == nil && (decryptedValue == "" || decryptedValue == UnlockPasswordCheck)
 }
 
 func (cfg *Config) SavePasswordCheck(encryptionKey string) {


### PR DESCRIPTION
Related to https://github.com/getAlby/nostr-wallet-connect-next/issues/12

If the user does not set a password (due to skipping the welcome screen), then the user still needs to be able to unlock