### PR TITLE
copy libbreez_sdk_bindings.so  instead of wget'ing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,7 @@ COPY --from=frontend /build/frontend/dist ./frontend/dist
 
 RUN GOARCH=$(echo "$TARGETPLATFORM" | cut -d'/' -f2) go build -o main .
 
-#RUN wget https://github.com/breez/breez-sdk-go/raw/main/breez_sdk/lib/linux-amd64/libbreez_sdk_bindings.so
-RUN wget https://github.com/breez/breez-sdk-go/raw/v0.2.14/breez_sdk/lib/linux-amd64/libbreez_sdk_bindings.so
+RUN cp `find /go/pkg/mod/github.com/breez/ |grep linux-amd64 |grep libbreez_sdk_bindings.so` ./
 
 # Start a new, final image to reduce size.
 FROM debian as final


### PR DESCRIPTION
since libbreez_sdk_bindings.so  specific version is already present on /go/pkg/mod/github.com/breez/  we can just copy it instead of wget'ing a specific version from github repo