### PR TITLE
fix: casade response_events on request_events

### DIFF
--- a/migrations/202401191539_initial_migration.sql
+++ b/migrations/202401191539_initial_migration.sql
@@ -10,7 +10,7 @@ CREATE UNIQUE INDEX `idx_request_events_nostr_id` ON `request_events`(`nostr_id`
 CREATE INDEX `idx_request_events_app_id` ON `request_events`(`app_id`);
 CREATE INDEX idx_payment_sum ON payments (app_id, preimage, created_at);
 CREATE INDEX idx_request_events_app_id_and_id ON request_events(app_id, id);
-CREATE TABLE "response_events" (`id` integer,`nostr_id` text UNIQUE,`request_id` integer,`content` text,`state` text,`replied_at` datetime,`created_at` datetime,`updated_at` datetime,PRIMARY KEY (`id`),CONSTRAINT `fk_response_events_request_event` FOREIGN KEY (`request_id`) REFERENCES `request_events`(`id`));
+CREATE TABLE "response_events" (`id` integer,`nostr_id` text UNIQUE,`request_id` integer,`content` text,`state` text,`replied_at` datetime,`created_at` datetime,`updated_at` datetime,PRIMARY KEY (`id`),CONSTRAINT `fk_response_events_request_event` FOREIGN KEY (`request_id`) REFERENCES `request_events`(`id`) ON DELETE CASCADE);
 CREATE UNIQUE INDEX `idx_response_events_nostr_id` ON `response_events`(`nostr_id`);
 CREATE TABLE "user_configs" ("id"	integer, "key"	text NOT NULL UNIQUE, "value"	text, "encrypted"	numeric, `created_at` datetime,`updated_at` datetime, PRIMARY KEY("id"));
 CREATE UNIQUE INDEX "idx_user_configs_key" ON "user_configs" ("key");


### PR DESCRIPTION
## Description

Deleting apps after using it doesn't work as of now because using the app would populate the `request_events` and `response_events` tables and deletion of app casades the deletion of `app_permissions`, `payments` and `request_events` but the `response_events` which are linked to the `request_events` are not cascaded and that causes the issue.