### PR TITLE
doc: add instructions to deploy with docker to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Run NWC on your own node!
 
 ### Docker
 
-#### From Alby's Container Repository
+#### From Alby's Container Registry
 
 `docker run -p 8080:8080 ghcr.io/getalby/nostr-wallet-connect-next:latest`
 

--- a/README.md
+++ b/README.md
@@ -259,6 +259,10 @@ Run NWC on your own node!
 
 ### Docker
 
-`docker build . -t nwc-local --progress=plain`
+#### From Alby's Container Repository
 
-`docker run --env-file .env -p 8080:8080 nwc-local`
+`docker run -p 8080:8080 ghcr.io/getalby/nostr-wallet-connect-next:latest`
+
+#### From Source
+
+`docker run -p 8080:8080 $(docker build -q .)`


### PR DESCRIPTION
The idea is to make it easy for users to run this app in whatever way is convenient for them. These are one-line commands to deploy NWC using docker.