### PR TITLE
feat: litestream backups (WIP)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,12 @@ RUN cp `find /go/pkg/mod/github.com/get\!alby/ | grep libldk_node.so` ./
 FROM debian as final
 
 ENV LD_LIBRARY_PATH=/usr/lib/nwc
+
+# set LDK trace log level
+ENV LDK_LOG_LEVEL=2
+# set NWC debug log level
+ENV LOG_LEVEL=5
+
 #
 # # Copy the binaries and entrypoint from the builder image.
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
@@ -50,5 +56,7 @@ COPY --from=builder /build/libbreez_sdk_bindings.so /usr/lib/nwc/
 COPY --from=builder /build/libglalby_bindings.so /usr/lib/nwc/
 COPY --from=builder /build/libldk_node.so /usr/lib/nwc/
 COPY --from=builder /build/main /bin/
+
+# TODO: enable litestream if env variables are set
 
 ENTRYPOINT [ "/bin/main" ]

--- a/README.md
+++ b/README.md
@@ -97,6 +97,19 @@ _If you get a blank screen the first load, close the window and start the app ag
 
 Breez SDK requires gcc to build the Breez bindings. Run `choco install mingw` and copy the breez SDK bindings file into the root of this directory (from your go installation directory) as per the [Breez SDK instructions](https://github.com/breez/breez-sdk-go?tab=readme-ov-file#windows). ALSO copy the bindings file into the output directory alongside the .exe in order to run it.
 
+### Run with Litestream backups (development)
+
+1. `docker run -p 9000:9000 -p 9001:9001 minio/minio server /data --console-address ":9001"`
+
+2. Access `http://127.0.0.1:9001` and login with username: `minioadmin` password: `minioadmin`
+
+3. create a bucket called `nwc`
+
+4. Use following command to run NWC `litestream replicate -config litestream.config`
+
+5. To restore files (each one must be restored individually):
+   `LITESTREAM_ACCESS_KEY_ID=minioadmin LITESTREAM_SECRET_ACCESS_KEY=minioadmin litestream restore -o nwc_restored.db s3://nwc.localhost:9000/nwc.db`
+
 ## Optional configuration parameters
 
 - `NOSTR_PRIVKEY`: the private key of this service. Should be a securely randomly generated 32 byte hex string.

--- a/litestream.config
+++ b/litestream.config
@@ -1,0 +1,15 @@
+# See https://litestream.io/getting-started/
+access-key-id:     minioadmin
+secret-access-key: minioadmin
+
+exec: go run .
+dbs:
+  - path: .data/nwc.db
+    replicas:
+      - url: s3://nwc.localhost:9000/nwc.db
+  - path: .data/ldk/storage/ldk_node_data.sqlite
+    replicas:
+      - url: s3://nwc.localhost:9000/ldk_node_data.sqlite
+  - path: .data/ldk/storage/nwc_bdk_wallet_backup.sqlite
+    replicas:
+      - url: s3://nwc.localhost:9000/nwc_bdk_wallet_backup.sqlite

--- a/service.go
+++ b/service.go
@@ -88,6 +88,8 @@ func NewService(ctx context.Context) (*Service, error) {
 	}
 	// Enable foreign keys for sqlite
 	db.Exec("PRAGMA foreign_keys=ON;")
+	// Wait for up to 5 seconds if there is a lock on the database
+	db.Exec("PRAGMA busy_timeout = 5000;")
 	sqlDb, err = db.DB()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Currently the 3 essential database files can be backed up to litestream. For BDK, a hard link is created and the original filename stored in the user config to circumvent the random hash in the filename.

Fixes https://github.com/getAlby/nostr-wallet-connect-next/issues/40
- [ ] confirm hard-linked bdk wallet file updates are persisted in litestream DB - connect to the sqlite database manually and make a change
- [ ] generate bucket in advance for each user
- [ ] update dockerfile to use litestream
- [ ] confirm how we do the restore flow - we would need to use litestream to restore these files on the user behalf, zip them and send them to the user
  - [ ] generate script to restore all files to a zip file
- [ ] import backup UI
- [ ] import backup backend (should accept a zip with `nwc.db`, `nwc_bdk_wallet_backup.sqlite`, `ldk_node_data.sqlite`)
- [ ] manual backup UI (Is it needed? it'll always be out of date)
- [ ] review encryption
- [ ] is it OK to do backups in this way? there is a small chance of missing a payment in the way litestream syncs. https://litestream.io/tips/#data-loss-window
