### PR TITLE
feat: improve LDK get info response

### DIFF
--- a/ldk.go
+++ b/ldk.go
@@ -25,6 +25,7 @@ type LDKService struct {
 	node                *ldk_node.Node
 	ldkEventBroadcaster LDKEventBroadcaster
 	cancel              context.CancelFunc
+	network             string
 }
 
 func NewLDKService(svc *Service, mnemonic, workDir string, network string, esploraServer string, gossipSource string) (result lnclient.LNClient, err error) {
@@ -113,6 +114,7 @@ func NewLDKService(svc *Service, mnemonic, workDir string, network string, esplo
 		}
 	}()
 
+	// TODO: rename "gs" in this file
 	gs := LDKService{
 		workdir: newpath,
 		node:    node,
@@ -120,6 +122,7 @@ func NewLDKService(svc *Service, mnemonic, workDir string, network string, esplo
 		svc:                 svc,
 		cancel:              cancel,
 		ldkEventBroadcaster: NewLDKEventBroadcaster(svc.Logger, ctx, ldkEventConsumer),
+		network:             network,
 	}
 
 	nodeId := node.NodeId()
@@ -435,13 +438,16 @@ func (gs *LDKService) ListTransactions(ctx context.Context, from, until, limit, 
 }
 
 func (gs *LDKService) GetInfo(ctx context.Context) (info *lnclient.NodeInfo, err error) {
+	// TODO: should alias, color be configured in LDK-node? or can we manage them in NWC?
+	// an alias is only needed if the user has public channels and wants their node to be publicly visible?
+	status := gs.node.Status()
 	return &lnclient.NodeInfo{
-		// Alias:       nodeInfo.Alias,
-		// Color:       nodeInfo.Color,
-		Pubkey: gs.node.NodeId(),
-		// Network:     nodeInfo.Network,
-		// BlockHeight: nodeInfo.BlockHeight,
-		BlockHash: "",
+		Alias:       "NWC",
+		Color:       "#897FFF",
+		Pubkey:      gs.node.NodeId(),
+		Network:     gs.network,
+		BlockHeight: status.CurrentBestBlock.Height,
+		BlockHash:   status.CurrentBestBlock.BlockHash,
 	}, nil
 }
 


### PR DESCRIPTION
example output from JS SDK nwc client:
```
{
  alias: 'NWC',
  color: '#897FFF',
  pubkey: '03c0ceddcfb1339b5c024368444278a3849d71d55c21e4fa81d0a43c0cff6cf99e',
  network: 'bitcoin',
  block_height: 835732,
  block_hash: '000000000000000000029a95a15b781c49ba05915bcacdd6b096211c7bf5ea69',
  methods: [ 'get_info' ]
}
```