### PR TITLE
feat: log events

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,11 @@
 #RELAY=ws://localhost:7447/v1
 #PORT=8080
 
+# Alby OAuth configuration
+#ALBY_OAUTH_CLIENT_SECRET=
+#ALBY_OAUTH_CLIENT_ID=
+#BASE_URL=
+
 # Polar LND Client
 #LN_BACKEND_TYPE=LND
 #LND_CERT_FILE=/home/YOUR_USERNAME/.polar/networks/1/volumes/lnd/alice/tls.cert

--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ _To configure via env, the following parameters must be provided:_
 - `LDK_ESPLORA_SERVER=https://mutinynet.com/api`
 - `LDK_GOSSIP_SOURCE=https://rgs.mutinynet.com/snapshot`
 
+### Alby OAuth
+
+Create an OAuth client at the [Alby Developer Portal](https://getalby.com/developer) and set your `ALBY_OAUTH_CLIENT_ID` and `ALBY_OAUTH_CLIENT_SECRET` in your .env. If not running locally, you'll also need to change your `BASE_URL`.
+
+> If running the React app locally, OAuth redirects will not work locally if running the react app you will need to manually change the port to 5173. **Login in Wails mode is not yet supported**
+
 ## Application deeplink options
 
 ### `/apps/new` deeplink options

--- a/alby/alby.go
+++ b/alby/alby.go
@@ -301,9 +301,7 @@ func (svc *AlbyOAuthService) Log(ctx context.Context, event *events.Event) error
 		return err
 	}
 
-	// FIXME: use actual URL
-	//req, err := http.NewRequest("POST", fmt.Sprintf("%s/events", svc.appConfig.AlbyAPIURL), body)
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/events", "http://localhost:3000/api"), body)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/events", svc.appConfig.AlbyAPIURL), body)
 	if err != nil {
 		svc.logger.WithError(err).Error("Error creating request /events")
 		return err

--- a/alby/alby.go
+++ b/alby/alby.go
@@ -92,7 +92,7 @@ var tokenMutex sync.Mutex
 func (svc *AlbyOAuthService) fetchUserToken(ctx context.Context) (*oauth2.Token, error) {
 	tokenMutex.Lock()
 	defer tokenMutex.Unlock()
-	accessToken, err := svc.kvStore.Get("AccessToken", "")
+	accessToken, err := svc.kvStore.Get(ACCESS_TOKEN_KEY, "")
 	if err != nil {
 		return nil, err
 	}

--- a/alby/alby_http_service.go
+++ b/alby/alby_http_service.go
@@ -40,10 +40,8 @@ func (albyHttpSvc *AlbyHttpService) albyCallbackHandler(c echo.Context) error {
 		})
 	}
 
-	// FIXME: redirect to the correct place
-	//return c.Redirect(302, "/")
 	// FIXME: redirects will not work for wails
-	return c.Redirect(302, "http://localhost:5173/#/channels/first")
+	return c.Redirect(302, albyHttpSvc.albyOAuthSvc.appConfig.BaseUrl+"/#/channels/first")
 }
 
 func (albyHttpSvc *AlbyHttpService) albyMeHandler(c echo.Context) error {

--- a/api.go
+++ b/api.go
@@ -334,12 +334,9 @@ func (api *API) Stop() error {
 	if api.svc.lnClient == nil {
 		return errors.New("LNClient not started")
 	}
-	// Shut down the lnclient
+	// stop the lnclient
 	// The user will be forced to re-enter their unlock password to restart the node
-	err := api.svc.lnClient.Shutdown()
-	if err == nil {
-		api.svc.lnClient = nil
-	}
+	err := api.svc.StopLNClient()
 	return err
 }
 

--- a/events/event_logger.go
+++ b/events/event_logger.go
@@ -1,0 +1,50 @@
+package events
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+)
+
+type EventListener interface {
+	Log(ctx context.Context, event *Event) error
+}
+
+type Event struct {
+	Event      string      `json:"event"`
+	Properties interface{} `json:"properties,omitempty"`
+}
+
+type eventLogger struct {
+	logger    *logrus.Logger
+	listeners []EventListener
+}
+
+type EventLogger interface {
+	Subscribe(eventListener EventListener)
+	Log(ctx context.Context, event *Event)
+}
+
+func NewEventLogger(logger *logrus.Logger) *eventLogger {
+	eventLogger := &eventLogger{
+		logger:    logger,
+		listeners: []EventListener{},
+	}
+	return eventLogger
+}
+
+func (el *eventLogger) Subscribe(listener EventListener) {
+	el.listeners = append(el.listeners, listener)
+}
+
+func (el *eventLogger) Log(ctx context.Context, event *Event) {
+	el.logger.WithField("event", event).Info("Logging event")
+	for _, listener := range el.listeners {
+		go func(listener EventListener) {
+			err := listener.Log(ctx, event)
+			if err != nil {
+				el.logger.WithError(err).Error("Failed to log event")
+			}
+		}(listener)
+	}
+}

--- a/handle_multi_pay_keysend_request.go
+++ b/handle_multi_pay_keysend_request.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync"
 
+	"github.com/getAlby/nostr-wallet-connect/events"
 	"github.com/nbd-wtf/go-nostr"
 	"github.com/sirupsen/logrus"
 )
@@ -83,6 +85,15 @@ func (svc *Service) HandleMultiPayKeysendEvent(ctx context.Context, request *Nip
 					"appId":           app.ID,
 					"recipientPubkey": keysendInfo.Pubkey,
 				}).Infof("Failed to send payment: %v", err)
+				svc.EventLogger.Log(ctx, &events.Event{
+					Event: "nwc_payment_failed",
+					Properties: map[string]interface{}{
+						"error":   fmt.Sprintf("%v", err),
+						"keysend": true,
+						"multi":   true,
+						"amount":  keysendInfo.Amount / 1000,
+					},
+				})
 
 				publishResponse(&Nip47Response{
 					ResultType: request.Method,
@@ -97,6 +108,14 @@ func (svc *Service) HandleMultiPayKeysendEvent(ctx context.Context, request *Nip
 			mu.Lock()
 			svc.db.Save(&payment)
 			mu.Unlock()
+			svc.EventLogger.Log(ctx, &events.Event{
+				Event: "nwc_payment_succeeded",
+				Properties: map[string]interface{}{
+					"keysend": true,
+					"multi":   true,
+					"amount":  keysendInfo.Amount / 1000,
+				},
+			})
 			publishResponse(&Nip47Response{
 				ResultType: request.Method,
 				Result: Nip47PayResponse{

--- a/handle_pay_keysend_request.go
+++ b/handle_pay_keysend_request.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
+	"github.com/getAlby/nostr-wallet-connect/events"
 	"github.com/sirupsen/logrus"
 )
 
@@ -56,6 +58,14 @@ func (svc *Service) HandlePayKeysendEvent(ctx context.Context, request *Nip47Req
 			"appId":           app.ID,
 			"recipientPubkey": payParams.Pubkey,
 		}).Infof("Failed to send payment: %v", err)
+		svc.EventLogger.Log(ctx, &events.Event{
+			Event: "nwc_payment_failed",
+			Properties: map[string]interface{}{
+				"error":   fmt.Sprintf("%v", err),
+				"keysend": true,
+				"amount":  payParams.Amount / 1000,
+			},
+		})
 		return &Nip47Response{
 			ResultType: request.Method,
 			Error: &Nip47Error{
@@ -66,6 +76,13 @@ func (svc *Service) HandlePayKeysendEvent(ctx context.Context, request *Nip47Req
 	}
 	payment.Preimage = &preimage
 	svc.db.Save(&payment)
+	svc.EventLogger.Log(ctx, &events.Event{
+		Event: "nwc_payment_succeeded",
+		Properties: map[string]interface{}{
+			"keysend": true,
+			"amount":  payParams.Amount / 1000,
+		},
+	})
 	return &Nip47Response{
 		ResultType: request.Method,
 		Result: Nip47PayResponse{

--- a/http_service.go
+++ b/http_service.go
@@ -29,11 +29,10 @@ const (
 )
 
 func NewHttpService(svc *Service) *HttpService {
-	albyOAuthSvc, _ := alby.NewAlbyOauthService(svc.Logger, svc.cfg, svc.cfg.Env)
 	return &HttpService{
 		svc:         svc,
-		api:         NewAPI(svc, albyOAuthSvc),
-		albyHttpSvc: alby.NewAlbyHttpService(albyOAuthSvc, svc.Logger),
+		api:         NewAPI(svc, svc.AlbyOAuthSvc),
+		albyHttpSvc: alby.NewAlbyHttpService(svc.AlbyOAuthSvc, svc.Logger),
 	}
 }
 

--- a/http_service.go
+++ b/http_service.go
@@ -7,6 +7,7 @@ import (
 
 	echologrus "github.com/davrux/echo-logrus/v4"
 	"github.com/getAlby/nostr-wallet-connect/alby"
+	"github.com/getAlby/nostr-wallet-connect/events"
 	"github.com/getAlby/nostr-wallet-connect/frontend"
 	"github.com/getAlby/nostr-wallet-connect/models/api"
 	models "github.com/getAlby/nostr-wallet-connect/models/http"
@@ -186,6 +187,10 @@ func (httpSvc *HttpService) unlockHandler(c echo.Context) error {
 			Message: fmt.Sprintf("Failed to save session: %s", err.Error()),
 		})
 	}
+
+	httpSvc.svc.EventLogger.Log(c.Request().Context(), &events.Event{
+		Event: "nwc_unlocked",
+	})
 
 	return c.NoContent(http.StatusNoContent)
 }

--- a/ldk.go
+++ b/ldk.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/getAlby/ldk-node-go/ldk_node"
+	"github.com/getAlby/nostr-wallet-connect/events"
 	"github.com/getAlby/nostr-wallet-connect/models/lnclient"
 	"github.com/getAlby/nostr-wallet-connect/models/lsp"
 	decodepay "github.com/nbd-wtf/ln-decodepay"
@@ -26,6 +27,7 @@ type LDKService struct {
 	ldkEventBroadcaster LDKEventBroadcaster
 	cancel              context.CancelFunc
 	network             string
+	eventLogger         events.EventLogger
 }
 
 func NewLDKService(svc *Service, mnemonic, workDir string, network string, esploraServer string, gossipSource string) (result lnclient.LNClient, err error) {
@@ -81,14 +83,19 @@ func NewLDKService(svc *Service, mnemonic, workDir string, network string, esplo
 		return nil, err
 	}
 
-	err = node.Start()
-	if err != nil {
-		svc.Logger.Errorf("Failed to start LDK node: %v", err)
-		return nil, err
-	}
-
 	ldkEventConsumer := make(chan *ldk_node.Event)
 	ctx, cancel := context.WithCancel(svc.ctx)
+	ldkEventBroadcaster := NewLDKEventBroadcaster(svc.Logger, ctx, ldkEventConsumer)
+
+	ls := LDKService{
+		workdir:             newpath,
+		node:                node,
+		svc:                 svc,
+		cancel:              cancel,
+		ldkEventBroadcaster: ldkEventBroadcaster,
+		network:             network,
+		eventLogger:         svc.EventLogger,
+	}
 
 	// check for and forward new LDK events to LDKEventBroadcaster (through ldkEventConsumer)
 	go func() {
@@ -106,9 +113,7 @@ func NewLDKService(svc *Service, mnemonic, workDir string, network string, esplo
 					continue
 				}
 
-				svc.Logger.WithFields(logrus.Fields{
-					"event": event,
-				}).Info("Received LDK event")
+				ls.logLdkEvent(ctx, event)
 				ldkEventConsumer <- event
 
 				node.EventHandled()
@@ -116,15 +121,10 @@ func NewLDKService(svc *Service, mnemonic, workDir string, network string, esplo
 		}
 	}()
 
-	// TODO: rename "gs" in this file
-	gs := LDKService{
-		workdir: newpath,
-		node:    node,
-		//listener: &listener,
-		svc:                 svc,
-		cancel:              cancel,
-		ldkEventBroadcaster: NewLDKEventBroadcaster(svc.Logger, ctx, ldkEventConsumer),
-		network:             network,
+	err = node.Start()
+	if err != nil {
+		svc.Logger.Errorf("Failed to start LDK node: %v", err)
+		return nil, err
 	}
 
 	nodeId := node.NodeId()
@@ -137,7 +137,7 @@ func NewLDKService(svc *Service, mnemonic, workDir string, network string, esplo
 		"nodeId": nodeId,
 	}).Info("Connected to LDK node")
 
-	return &gs, nil
+	return &ls, nil
 }
 
 func (gs *LDKService) Shutdown() error {
@@ -148,12 +148,33 @@ func (gs *LDKService) Shutdown() error {
 	return nil
 }
 
-func (gs *LDKService) SendPaymentSync(ctx context.Context, payReq string) (preimage string, err error) {
+func (gs *LDKService) SendPaymentSync(ctx context.Context, invoice string) (preimage string, err error) {
+	maxSendable := gs.getMaxSendable()
+
+	paymentRequest, err := decodepay.Decodepay(invoice)
+	if err != nil {
+		gs.svc.Logger.WithFields(logrus.Fields{
+			"bolt11": invoice,
+		}).Errorf("Failed to decode bolt11 invoice: %v", err)
+
+		return "", err
+	}
+
+	gs.eventLogger.Log(ctx, &events.Event{
+		Event: "nwc_ldk_send_payment",
+		Properties: map[string]interface{}{
+			"invoice":      invoice,
+			"amount":       paymentRequest.MSatoshi / 1000,
+			"max_sendable": maxSendable,
+			"num_channels": len(gs.node.ListChannels()),
+		},
+	})
+
 	paymentStart := time.Now()
 	ldkEventSubscription := gs.ldkEventBroadcaster.Subscribe()
 	defer gs.ldkEventBroadcaster.CancelSubscription(ldkEventSubscription)
 
-	paymentHash, err := gs.node.Bolt11Payment().Send(payReq)
+	paymentHash, err := gs.node.Bolt11Payment().Send(invoice)
 	if err != nil {
 		gs.svc.Logger.WithError(err).Error("SendPayment failed")
 		return "", err
@@ -221,6 +242,15 @@ func (gs *LDKService) SendPaymentSync(ctx context.Context, payReq string) (preim
 				"failureReason":        failureReason,
 				"failureReasonMessage": failureReasonMessage,
 			}).Error("Received payment failed event")
+
+			gs.eventLogger.Log(ctx, &events.Event{
+				Event: "nwc_ldk_payment_failed",
+				Properties: map[string]interface{}{
+					"invoice":        invoice,
+					"reason":         failureReason,
+					"reason_message": failureReasonMessage,
+				},
+			})
 
 			return "", fmt.Errorf("payment failed event: %v %s", failureReason, failureReasonMessage)
 		}
@@ -343,13 +373,48 @@ func (gs *LDKService) GetBalance(ctx context.Context) (balance int64, err error)
 
 	balance = 0
 	for _, channel := range channels {
-		balance += int64(channel.OutboundCapacityMsat)
+		if channel.IsUsable {
+			balance += int64(channel.OutboundCapacityMsat)
+		}
 	}
 
 	return balance, nil
 }
 
+func (gs *LDKService) getMaxReceivable() int64 {
+	var receivable int64 = 0
+	channels := gs.node.ListChannels()
+	for _, channel := range channels {
+		if channel.IsUsable {
+			receivable += min(int64(channel.InboundCapacityMsat), int64(*channel.InboundHtlcMaximumMsat))
+		}
+	}
+	return int64(receivable)
+}
+
+func (gs *LDKService) getMaxSendable() int64 {
+	var spendable int64 = 0
+	channels := gs.node.ListChannels()
+	for _, channel := range channels {
+		if channel.IsUsable {
+			spendable += min(int64(channel.OutboundCapacityMsat), int64(*channel.CounterpartyOutboundHtlcMaximumMsat))
+		}
+	}
+	return int64(spendable)
+}
+
 func (gs *LDKService) MakeInvoice(ctx context.Context, amount int64, description string, descriptionHash string, expiry int64) (transaction *Nip47Transaction, err error) {
+
+	maxReceivable := gs.getMaxReceivable()
+
+	gs.eventLogger.Log(ctx, &events.Event{
+		Event: "nwc_ldk_make_invoice",
+		Properties: map[string]interface{}{
+			"amount":         amount / 1000,
+			"max_receivable": maxReceivable,
+			"num_channels":   len(gs.node.ListChannels()),
+		},
+	})
 
 	// TODO: support passing description hash
 	invoice, err := gs.node.Bolt11Payment().Receive(uint64(amount),
@@ -683,4 +748,45 @@ func (gs *LDKService) ldkPaymentToTransaction(payment *ldk_node.PaymentDetails) 
 		DescriptionHash: descriptionHash,
 		ExpiresAt:       expiresAt,
 	}, nil
+}
+
+func (ls *LDKService) logLdkEvent(ctx context.Context, event *ldk_node.Event) {
+	ls.svc.Logger.WithFields(logrus.Fields{
+		"event": event,
+	}).Info("Received LDK event")
+
+	switch v := (*event).(type) {
+	case ldk_node.EventChannelReady:
+		ls.eventLogger.Log(ctx, &events.Event{
+			Event: "nwc_ldk_channel_ready",
+			Properties: map[string]interface{}{
+				"counterparty_node_id": v.CounterpartyNodeId,
+			},
+		})
+	case ldk_node.EventChannelClosed:
+		ls.eventLogger.Log(ctx, &events.Event{
+			Event: "nwc_ldk_channel_closed",
+			Properties: map[string]interface{}{
+				"counterparty_node_id": v.CounterpartyNodeId,
+				"reason":               fmt.Sprintf("%+v", v.Reason),
+			},
+		})
+	case ldk_node.EventPaymentReceived:
+		ls.eventLogger.Log(ctx, &events.Event{
+			Event: "nwc_ldk_payment_received",
+			Properties: map[string]interface{}{
+				"payment_hash": v.PaymentHash,
+				"amount":       v.AmountMsat / 1000,
+			},
+		})
+	case ldk_node.EventPaymentFailed:
+		ls.eventLogger.Log(ctx, &events.Event{
+			Event: "nwc_ldk_payment_failed",
+			Properties: map[string]interface{}{
+				"payment_hash": v.PaymentHash,
+				"reason":       fmt.Sprintf("%+v", v.Reason),
+			},
+		})
+	}
+
 }

--- a/models/config/config.go
+++ b/models/config/config.go
@@ -8,26 +8,26 @@ const (
 )
 
 type AppConfig struct {
-	Relay                string `envconfig:"RELAY" default:"wss://relay.getalby.com/v1"`
-	LNBackendType        string `envconfig:"LN_BACKEND_TYPE"`
-	LNDAddress           string `envconfig:"LND_ADDRESS"`
-	LNDCertFile          string `envconfig:"LND_CERT_FILE"`
-	LNDMacaroonFile      string `envconfig:"LND_MACAROON_FILE"`
-	Workdir              string `envconfig:"WORK_DIR" default:".data"`
-	Port                 string `envconfig:"PORT" default:"8080"`
-	DatabaseUri          string `envconfig:"DATABASE_URI" default:".data/nwc.db"`
-	CookieSecret         string `envconfig:"COOKIE_SECRET"`
-	LogLevel             string `envconfig:"LOG_LEVEL"`
-	LDKNetwork           string `envconfig:"LDK_NETWORK" default:"bitcoin"`
-	LDKEsploraServer     string `envconfig:"LDK_ESPLORA_SERVER" default:"https://blockstream.info/api"`
-	LDKGossipSource      string `envconfig:"LDK_GOSSIP_SOURCE" default:"https://rapidsync.lightningdevkit.org/snapshot"`
-	LDKLogLevel          string `envconfig:"LDK_LOG_LEVEL"`
-	MempoolApi           string `envconfig:"MEMPOOL_API" default:"https://mempool.space/api"`
-	AlbyAPIURL           string `envconfig:"ALBY_API_URL" default:"https://api.getalby.com"`
-	AlbyClientId         string `envconfig:"ALBY_OAUTH_CLIENT_ID"`
-	AlbyClientSecret     string `envconfig:"ALBY_OAUTH_CLIENT_SECRET"`
-	AlbyOAuthRedirectUrl string `envconfig:"ALBY_OAUTH_REDIRECT_URL"`
-	AlbyOAuthAuthUrl     string `envconfig:"ALBY_OAUTH_AUTH_URL" default:"https://getalby.com/oauth"`
+	Relay            string `envconfig:"RELAY" default:"wss://relay.getalby.com/v1"`
+	LNBackendType    string `envconfig:"LN_BACKEND_TYPE"`
+	LNDAddress       string `envconfig:"LND_ADDRESS"`
+	LNDCertFile      string `envconfig:"LND_CERT_FILE"`
+	LNDMacaroonFile  string `envconfig:"LND_MACAROON_FILE"`
+	Workdir          string `envconfig:"WORK_DIR" default:".data"`
+	Port             string `envconfig:"PORT" default:"8080"`
+	DatabaseUri      string `envconfig:"DATABASE_URI" default:".data/nwc.db"`
+	CookieSecret     string `envconfig:"COOKIE_SECRET"`
+	LogLevel         string `envconfig:"LOG_LEVEL"`
+	LDKNetwork       string `envconfig:"LDK_NETWORK" default:"bitcoin"`
+	LDKEsploraServer string `envconfig:"LDK_ESPLORA_SERVER" default:"https://blockstream.info/api"`
+	LDKGossipSource  string `envconfig:"LDK_GOSSIP_SOURCE" default:"https://rapidsync.lightningdevkit.org/snapshot"`
+	LDKLogLevel      string `envconfig:"LDK_LOG_LEVEL"`
+	MempoolApi       string `envconfig:"MEMPOOL_API" default:"https://mempool.space/api"`
+	AlbyAPIURL       string `envconfig:"ALBY_API_URL" default:"https://api.getalby.com"`
+	AlbyClientId     string `envconfig:"ALBY_OAUTH_CLIENT_ID"`
+	AlbyClientSecret string `envconfig:"ALBY_OAUTH_CLIENT_SECRET"`
+	AlbyOAuthAuthUrl string `envconfig:"ALBY_OAUTH_AUTH_URL" default:"https://getalby.com/oauth"`
+	BaseUrl          string `envconfig:"BASE_URL" default:"http://localhost:8080"`
 }
 
 type ConfigKVStore interface {

--- a/service_test.go
+++ b/service_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/getAlby/nostr-wallet-connect/events"
 	"github.com/getAlby/nostr-wallet-connect/migrations"
 	"github.com/getAlby/nostr-wallet-connect/models/config"
 	"github.com/getAlby/nostr-wallet-connect/models/lnclient"
@@ -1203,9 +1204,10 @@ func createTestService(ln *MockLn) (svc *Service, err error) {
 			NostrSecretKey: sk,
 			NostrPublicKey: pk,
 		},
-		db:       gormDb,
-		lnClient: ln,
-		Logger:   logger,
+		db:          gormDb,
+		lnClient:    ln,
+		Logger:      logger,
+		EventLogger: events.NewEventLogger(logger),
 	}, nil
 }
 

--- a/start.go
+++ b/start.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/getAlby/nostr-wallet-connect/events"
 	"github.com/nbd-wtf/go-nostr"
 	"github.com/nbd-wtf/go-nostr/nip19"
 )
@@ -120,11 +121,10 @@ func (svc *Service) StartApp(encryptionKey string) error {
 }
 
 func (svc *Service) Shutdown() {
-	if svc.lnClient != nil {
-		svc.Logger.Info("Shutting down LN backend...")
-		err := svc.lnClient.Shutdown()
-		if err != nil {
-			svc.Logger.Error(err)
-		}
-	}
+	svc.StopLNClient()
+	svc.EventLogger.Log(svc.ctx, &events.Event{
+		Event: "nwc_stopped",
+	})
+	// wait for any remaining events
+	time.Sleep(1 * time.Second)
 }

--- a/wails_app.go
+++ b/wails_app.go
@@ -5,7 +5,6 @@ import (
 	"embed"
 	"log"
 
-	alby "github.com/getAlby/nostr-wallet-connect/alby"
 	"github.com/sirupsen/logrus"
 	"github.com/wailsapp/wails/v2"
 	"github.com/wailsapp/wails/v2/pkg/options"
@@ -22,10 +21,9 @@ type WailsApp struct {
 }
 
 func NewApp(svc *Service) *WailsApp {
-	albyOAuthSvc, _ := alby.NewAlbyOauthService(svc.Logger, svc.cfg, svc.cfg.Env)
 	return &WailsApp{
 		svc: svc,
-		api: NewAPI(svc, albyOAuthSvc),
+		api: NewAPI(svc, svc.AlbyOAuthSvc),
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/getAlby/nostr-wallet-connect-next/issues/52

The current design supports multiple subscribers (if we wanted to also send nostr DMs from the NWC app, and maybe handle events for other purposes e.g. achievements - but I'm not sure here because the event properties are untyped). Events are handled in separate goroutines to be non-blocking.

Go to http://localhost:5173/#/channels/first to connect your Alby account.

This assumes that NWC is actively running and being used so that the refresh token can always be used to get a new access token.

Before the user connects their Alby account, events will fail to be sent.

There are three events fired right now:
- `nwc_started` (currently has no properties - maybe we could include the version number)
- `nwc_unlocked` (http mode only)
- `nwc_node_started`

If the current approach looks ok, I will add more events