### PR TITLE
chore: only pass svc to NewAPI

### DIFF
--- a/api.go
+++ b/api.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"time"
 
-	alby "github.com/getAlby/nostr-wallet-connect/alby"
 	"github.com/nbd-wtf/go-nostr"
 	"gorm.io/gorm"
 
@@ -24,15 +23,13 @@ import (
 )
 
 type API struct {
-	svc          *Service
-	albyOAuthSvc *alby.AlbyOAuthService
+	svc *Service
 }
 
-func NewAPI(svc *Service, albyOAuthSvc *alby.AlbyOAuthService) *API {
+func NewAPI(svc *Service) *API {
 
 	return &API{
-		svc:          svc,
-		albyOAuthSvc: albyOAuthSvc,
+		svc: svc,
 	}
 }
 
@@ -649,8 +646,8 @@ func (api *API) GetInfo() (*models.InfoResponse, error) {
 	info.SetupCompleted = unlockPasswordCheck != ""
 	info.Running = api.svc.lnClient != nil
 	info.BackendType = backendType
-	info.AlbyAuthUrl = api.albyOAuthSvc.GetAuthUrl()
-	info.AlbyUserIdentifier = api.albyOAuthSvc.GetUserIdentifier()
+	info.AlbyAuthUrl = api.svc.AlbyOAuthSvc.GetAuthUrl()
+	info.AlbyUserIdentifier = api.svc.AlbyOAuthSvc.GetUserIdentifier()
 
 	if info.BackendType != config.LNDBackendType {
 		nextBackupReminder, _ := api.svc.cfg.Get("NextBackupReminder", "")

--- a/http_service.go
+++ b/http_service.go
@@ -33,7 +33,7 @@ const (
 func NewHttpService(svc *Service) *HttpService {
 	return &HttpService{
 		svc:         svc,
-		api:         NewAPI(svc, svc.AlbyOAuthSvc),
+		api:         NewAPI(svc),
 		albyHttpSvc: alby.NewAlbyHttpService(svc.AlbyOAuthSvc, svc.Logger),
 	}
 }

--- a/wails_app.go
+++ b/wails_app.go
@@ -23,7 +23,7 @@ type WailsApp struct {
 func NewApp(svc *Service) *WailsApp {
 	return &WailsApp{
 		svc: svc,
-		api: NewAPI(svc, svc.AlbyOAuthSvc),
+		api: NewAPI(svc),
 	}
 }
 


### PR DESCRIPTION
Doesn't make sense to pass `svc` and also pass `svc.AlbyOAuthSvc`, and especially when `svc.AlbyOAuthSvc` is only being used twice in NewAPI methods