### PR TITLE
feat: api call to get onchain and lightning balances

### DIFF
--- a/api.go
+++ b/api.go
@@ -405,6 +405,17 @@ func (api *API) GetOnchainBalance(ctx context.Context) (*models.OnchainBalanceRe
 	return balance, nil
 }
 
+func (api *API) GetBalances(ctx context.Context) (*models.BalancesResponse, error) {
+	if api.svc.lnClient == nil {
+		return nil, errors.New("LNClient not started")
+	}
+	balances, err := api.svc.lnClient.GetBalances(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return balances, nil
+}
+
 func (api *API) GetMempoolLightningNode(pubkey string) (interface{}, error) {
 	url := api.svc.cfg.Env.MempoolApi + "/v1/lightning/nodes/" + pubkey
 

--- a/frontend/src/screens/channels/MigrateAlbyFunds.tsx
+++ b/frontend/src/screens/channels/MigrateAlbyFunds.tsx
@@ -180,7 +180,7 @@ export default function MigrateAlbyFunds() {
         Estimated Channel size: {estimatedChannelSize} sats
       </p>
       <p className="font-bold">
-        Estimated sendable: {amount - wrappedInvoiceResponse.fee} sats
+        Estimated spendable: {amount - wrappedInvoiceResponse.fee} sats
       </p>
       <p className="font-bold">
         Estimated receivable: {LSP_FREE_INCOMING - wrappedInvoiceResponse.fee}{" "}

--- a/http_service.go
+++ b/http_service.go
@@ -88,6 +88,7 @@ func (httpSvc *HttpService) RegisterSharedRoutes(e *echo.Echo) {
 	e.POST("/api/wallet/new-address", httpSvc.newOnchainAddressHandler, authMiddleware)
 	e.POST("/api/wallet/redeem-onchain-funds", httpSvc.redeemOnchainFundsHandler, authMiddleware)
 	e.GET("/api/wallet/balance", httpSvc.onchainBalanceHandler, authMiddleware)
+	e.GET("/api/balances", httpSvc.balancesHandler, authMiddleware)
 	e.POST("/api/reset-router", httpSvc.resetRouterHandler, authMiddleware)
 	e.POST("/api/stop", httpSvc.stopHandler, authMiddleware)
 
@@ -300,6 +301,20 @@ func (httpSvc *HttpService) onchainBalanceHandler(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, onchainBalanceResponse)
+}
+
+func (httpSvc *HttpService) balancesHandler(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	balances, err := httpSvc.api.GetBalances(ctx)
+
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, models.ErrorResponse{
+			Message: err.Error(),
+		})
+	}
+
+	return c.JSON(http.StatusOK, balances)
 }
 
 func (httpSvc *HttpService) mempoolLightningNodeHandler(c echo.Context) error {

--- a/lnd.go
+++ b/lnd.go
@@ -357,6 +357,28 @@ func (svc *LNDService) RedeemOnchainFunds(ctx context.Context, toAddress string)
 	return "", nil
 }
 
+func (svc *LNDService) GetBalances(ctx context.Context) (*lnclient.BalancesResponse, error) {
+	balance, err := svc.GetBalance(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &lnclient.BalancesResponse{
+		Onchain: lnclient.OnchainBalanceResponse{
+			Spendable: 0, // TODO: implement
+			Total:     0, // TODO: implement
+		},
+		Lightning: lnclient.LightningBalanceResponse{
+			TotalSpendable:       balance,
+			TotalReceivable:      0,       // TODO: implement
+			NextMaxSpendable:     balance, // TODO: implement
+			NextMaxReceivable:    0,       // TODO: implement
+			NextMaxSpendableMPP:  balance, // TODO: implement
+			NextMaxReceivableMPP: 0,       // TODO: implement
+		},
+	}, nil
+}
+
 func lndInvoiceToTransaction(invoice *lnrpc.Invoice) *Nip47Transaction {
 	var settledAt *int64
 	var preimage string

--- a/models/api/api.go
+++ b/models/api/api.go
@@ -126,6 +126,7 @@ type RedeemOnchainFundsResponse struct {
 }
 
 type OnchainBalanceResponse = lnclient.OnchainBalanceResponse
+type BalancesResponse = lnclient.BalancesResponse
 
 type NewOnchainAddressResponse struct {
 	Address string `json:"address"`

--- a/models/lnclient/lnclient.go
+++ b/models/lnclient/lnclient.go
@@ -56,6 +56,7 @@ type LNClient interface {
 	GetNewOnchainAddress(ctx context.Context) (string, error)
 	ResetRouter(ctx context.Context) error
 	GetOnchainBalance(ctx context.Context) (*OnchainBalanceResponse, error)
+	GetBalances(ctx context.Context) (*BalancesResponse, error)
 	RedeemOnchainFunds(ctx context.Context, toAddress string) (txId string, err error)
 }
 
@@ -95,4 +96,18 @@ type CloseChannelResponse struct {
 type OnchainBalanceResponse struct {
 	Spendable int64 `json:"spendable"`
 	Total     int64 `json:"total"`
+}
+
+type LightningBalanceResponse struct {
+	TotalSpendable       int64 `json:"totalSpendable"`
+	TotalReceivable      int64 `json:"totalReceivable"`
+	NextMaxSpendable     int64 `json:"nextMaxSpendable"`
+	NextMaxReceivable    int64 `json:"nextMaxReceivable"`
+	NextMaxSpendableMPP  int64 `json:"nextMaxSpendableMPP"`
+	NextMaxReceivableMPP int64 `json:"nextMaxReceivableMPP"`
+}
+
+type BalancesResponse struct {
+	Onchain   OnchainBalanceResponse   `json:"onchain"`
+	Lightning LightningBalanceResponse `json:"lightning"`
 }

--- a/service_test.go
+++ b/service_test.go
@@ -1303,6 +1303,9 @@ func (mln *MockLn) CloseChannel(ctx context.Context, closeChannelRequest *lnclie
 func (mln *MockLn) GetNewOnchainAddress(ctx context.Context) (string, error) {
 	return "", nil
 }
+func (mln *MockLn) GetBalances(ctx context.Context) (*lnclient.BalancesResponse, error) {
+	return nil, nil
+}
 func (mln *MockLn) GetOnchainBalance(ctx context.Context) (*lnclient.OnchainBalanceResponse, error) {
 	return nil, nil
 }

--- a/wails_handlers.go
+++ b/wails_handlers.go
@@ -164,6 +164,13 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 			}
 			return WailsRequestRouterResponse{Body: openChannelResponse, Error: ""}
 		}
+	case "/api/balances":
+		balancesResponse, err := app.api.GetBalances(ctx)
+		if err != nil {
+			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
+		}
+		res := WailsRequestRouterResponse{Body: *balancesResponse, Error: ""}
+		return res
 	case "/api/wallet/balance":
 		balanceResponse, err := app.api.GetOnchainBalance(ctx)
 		if err != nil {


### PR DESCRIPTION
This exposes onchain balances as well as useful lightning information regarding ingoing and outgoing liquidity. Not all values need necessarily be exposed in the UI.

Also fixes breez balance to only show the spendable amount

Fixes https://github.com/getAlby/nostr-wallet-connect-next/issues/181