### PR TITLE
fix: api for balance call

### DIFF
--- a/alby/alby.go
+++ b/alby/alby.go
@@ -216,7 +216,7 @@ func (svc *AlbyOAuthService) GetBalance(ctx context.Context) (*AlbyBalance, erro
 
 	client := svc.oauthConf.Client(ctx, token)
 
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/internal/lndhub/balance", svc.appConfig.AlbyAPIURL), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/balance", svc.appConfig.AlbyAPIURL), nil)
 	if err != nil {
 		svc.logger.WithError(err).Error("Error creating request to balance endpoint")
 		return nil, err


### PR DESCRIPTION
[API Reference](https://guides.getalby.com/developer-guide/v/alby-wallet-api/reference/api-reference/account#get-account-balance)

The current endpoint is giving EOF error
