### PR TITLE
chore: add config option to disable connecting alby account to NWC

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@
 #RELAY=ws://localhost:7447/v1
 #PORT=8080
 #FRONTEND_URL=http://localhost:5173
+#CONNECT_ALBY_ACCOUNT=false
 
 # Alby OAuth configuration
 #ALBY_OAUTH_CLIENT_SECRET=

--- a/alby/alby.go
+++ b/alby/alby.go
@@ -104,7 +104,13 @@ func (svc *AlbyOAuthService) CallbackHandler(ctx context.Context, code string) e
 		svc.config.SetUpdate(userIdentifierKey, me.Identifier, "")
 
 		// setup the Alby Account NWC node and connection
-		svc.connectAccount(ctx)
+		if svc.appConfig.ConnectAlbyAccount {
+			err = svc.connectAccount(ctx)
+			if err != nil {
+				svc.logger.WithError(err).Error("Failed to connect alby account")
+				// not sure what to do here, don't return the error for now.
+			}
+		}
 	}
 
 	return nil

--- a/models/config/config.go
+++ b/models/config/config.go
@@ -9,28 +9,29 @@ const (
 )
 
 type AppConfig struct {
-	Relay            string `envconfig:"RELAY" default:"wss://relay.getalby.com/v1"`
-	LNBackendType    string `envconfig:"LN_BACKEND_TYPE"`
-	LNDAddress       string `envconfig:"LND_ADDRESS"`
-	LNDCertFile      string `envconfig:"LND_CERT_FILE"`
-	LNDMacaroonFile  string `envconfig:"LND_MACAROON_FILE"`
-	Workdir          string `envconfig:"WORK_DIR"`
-	Port             string `envconfig:"PORT" default:"8080"`
-	DatabaseUri      string `envconfig:"DATABASE_URI" default:"nwc.db"`
-	CookieSecret     string `envconfig:"COOKIE_SECRET"`
-	LogLevel         string `envconfig:"LOG_LEVEL"`
-	LDKNetwork       string `envconfig:"LDK_NETWORK" default:"bitcoin"`
-	LDKEsploraServer string `envconfig:"LDK_ESPLORA_SERVER" default:"https://blockstream.info/api"`
-	LDKGossipSource  string `envconfig:"LDK_GOSSIP_SOURCE" default:"https://rapidsync.lightningdevkit.org/snapshot"`
-	LDKLogLevel      string `envconfig:"LDK_LOG_LEVEL"`
-	MempoolApi       string `envconfig:"MEMPOOL_API" default:"https://mempool.space/api"`
-	AlbyAPIURL       string `envconfig:"ALBY_API_URL" default:"https://api.getalby.com"`
-	AlbyClientId     string `envconfig:"ALBY_OAUTH_CLIENT_ID"`
-	AlbyClientSecret string `envconfig:"ALBY_OAUTH_CLIENT_SECRET"`
-	AlbyOAuthAuthUrl string `envconfig:"ALBY_OAUTH_AUTH_URL" default:"https://getalby.com/oauth"`
-	BaseUrl          string `envconfig:"BASE_URL" default:"http://localhost:8080"`
-	FrontendUrl      string `envconfig:"FRONTEND_URL"`
-	LogEvents        bool   `envconfig:"LOG_EVENTS" default:"false"`
+	Relay              string `envconfig:"RELAY" default:"wss://relay.getalby.com/v1"`
+	LNBackendType      string `envconfig:"LN_BACKEND_TYPE"`
+	LNDAddress         string `envconfig:"LND_ADDRESS"`
+	LNDCertFile        string `envconfig:"LND_CERT_FILE"`
+	LNDMacaroonFile    string `envconfig:"LND_MACAROON_FILE"`
+	Workdir            string `envconfig:"WORK_DIR"`
+	Port               string `envconfig:"PORT" default:"8080"`
+	DatabaseUri        string `envconfig:"DATABASE_URI" default:"nwc.db"`
+	CookieSecret       string `envconfig:"COOKIE_SECRET"`
+	LogLevel           string `envconfig:"LOG_LEVEL"`
+	LDKNetwork         string `envconfig:"LDK_NETWORK" default:"bitcoin"`
+	LDKEsploraServer   string `envconfig:"LDK_ESPLORA_SERVER" default:"https://blockstream.info/api"`
+	LDKGossipSource    string `envconfig:"LDK_GOSSIP_SOURCE" default:"https://rapidsync.lightningdevkit.org/snapshot"`
+	LDKLogLevel        string `envconfig:"LDK_LOG_LEVEL"`
+	MempoolApi         string `envconfig:"MEMPOOL_API" default:"https://mempool.space/api"`
+	AlbyAPIURL         string `envconfig:"ALBY_API_URL" default:"https://api.getalby.com"`
+	AlbyClientId       string `envconfig:"ALBY_OAUTH_CLIENT_ID"`
+	AlbyClientSecret   string `envconfig:"ALBY_OAUTH_CLIENT_SECRET"`
+	AlbyOAuthAuthUrl   string `envconfig:"ALBY_OAUTH_AUTH_URL" default:"https://getalby.com/oauth"`
+	BaseUrl            string `envconfig:"BASE_URL" default:"http://localhost:8080"`
+	FrontendUrl        string `envconfig:"FRONTEND_URL"`
+	LogEvents          bool   `envconfig:"LOG_EVENTS" default:"false"`
+	ConnectAlbyAccount bool   `envconfig:"CONNECT_ALBY_ACCOUNT" default:"true"`
 }
 
 type Config interface {


### PR DESCRIPTION
Auto-connecting in local development causes the current getalby.com connection to break. So I have added an env variable to be able to disable it (but it's enabled by default)