### PR TITLE
fix: remove the requirement to only pass either description or description hash when making an invoice

### DIFF
--- a/handle_make_invoice_request.go
+++ b/handle_make_invoice_request.go
@@ -23,22 +23,6 @@ func (svc *Service) HandleMakeInvoiceEvent(ctx context.Context, nip47Request *Ni
 		return
 	}
 
-	if makeInvoiceParams.Description != "" && makeInvoiceParams.DescriptionHash != "" {
-		svc.Logger.WithFields(logrus.Fields{
-			"requestEventNostrId": requestEvent.NostrId,
-			"appId":               app.ID,
-		}).Errorf("Only one of description, description_hash can be provided")
-
-		publishResponse(&Nip47Response{
-			ResultType: nip47Request.Method,
-			Error: &Nip47Error{
-				Code:    nip47.OTHER,
-				Message: "Only one of description, description_hash can be provided",
-			},
-		}, nostr.Tags{})
-		return
-	}
-
 	svc.Logger.WithFields(logrus.Fields{
 		"requestEventNostrId": requestEvent.NostrId,
 		"appId":               app.ID,


### PR DESCRIPTION
Fixes https://github.com/getAlby/nostr-wallet-connect-next/issues/243

- Greenlight: currently not affected (only description is being passed)
- Breez: currently not affected (only description is supported)
- LDK: this will only fix standard LNURL invoices with comments. It will not fix zaps. (requires change in LDK)
- LND: works (both description AND description hash are saved in the BOLT11 invoice)