### PR TITLE
feat: add payment fees to ldk + penalize routes with more hops, remove preimage check from budget calculation

### DIFF
--- a/breez.go
+++ b/breez.go
@@ -102,19 +102,21 @@ func (bs *BreezService) Shutdown() error {
 	return bs.svc.Disconnect()
 }
 
-func (bs *BreezService) SendPaymentSync(ctx context.Context, payReq string) (preimage string, err error) {
+func (bs *BreezService) SendPaymentSync(ctx context.Context, payReq string) (*lnclient.Nip47PayInvoiceResponse, error) {
 	sendPaymentRequest := breez_sdk.SendPaymentRequest{
 		Bolt11: payReq,
 	}
 	resp, err := bs.svc.SendPayment(sendPaymentRequest)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	var lnDetails breez_sdk.PaymentDetailsLn
 	if resp.Payment.Details != nil {
 		lnDetails, _ = resp.Payment.Details.(breez_sdk.PaymentDetailsLn)
 	}
-	return lnDetails.Data.PaymentPreimage, nil
+	return &lnclient.Nip47PayInvoiceResponse{
+		Preimage: lnDetails.Data.PaymentPreimage,
+	}, nil
 
 }
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/breez/breez-sdk-go v0.3.4
 	github.com/davrux/echo-logrus/v4 v4.0.3
 	github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8
-	github.com/getAlby/ldk-node-go v0.0.0-20240416174401-47e28c909be7
+	github.com/getAlby/ldk-node-go v0.0.0-20240508062012-79d039e31a38
 	github.com/go-gormigrate/gormigrate/v2 v2.1.1
 	github.com/gorilla/sessions v1.2.1
 	github.com/labstack/echo-contrib v0.14.1

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/breez/breez-sdk-go v0.3.4
 	github.com/davrux/echo-logrus/v4 v4.0.3
 	github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8
-	github.com/getAlby/ldk-node-go v0.0.0-20240508062012-79d039e31a38
+	github.com/getAlby/ldk-node-go v0.0.0-20240508193508-e18c07203ae1
 	github.com/go-gormigrate/gormigrate/v2 v2.1.1
 	github.com/gorilla/sessions v1.2.1
 	github.com/labstack/echo-contrib v0.14.1

--- a/go.sum
+++ b/go.sum
@@ -233,6 +233,8 @@ github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8 h1:mJsdhUb8hmSSS
 github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8/go.mod h1:ViyJvjlvv0GCesTJ7mb3fBo4G+/qsujDAFN90xZ7a9U=
 github.com/getAlby/ldk-node-go v0.0.0-20240416174401-47e28c909be7 h1:Zkyj4swlA5vaUPnybAd4awRt7N2tOhAFN7JEutY9FSA=
 github.com/getAlby/ldk-node-go v0.0.0-20240416174401-47e28c909be7/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
+github.com/getAlby/ldk-node-go v0.0.0-20240508062012-79d039e31a38 h1:RiR5Z9lyxrpXAKyQH61CLbjuMcA20hGEk3b8EXJlZeU=
+github.com/getAlby/ldk-node-go v0.0.0-20240508062012-79d039e31a38/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/go.sum
+++ b/go.sum
@@ -231,10 +231,8 @@ github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8 h1:mJsdhUb8hmSSSLR2GQFw9BGtnJP7xmKB/XQxDt3DvAo=
 github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8/go.mod h1:ViyJvjlvv0GCesTJ7mb3fBo4G+/qsujDAFN90xZ7a9U=
-github.com/getAlby/ldk-node-go v0.0.0-20240416174401-47e28c909be7 h1:Zkyj4swlA5vaUPnybAd4awRt7N2tOhAFN7JEutY9FSA=
-github.com/getAlby/ldk-node-go v0.0.0-20240416174401-47e28c909be7/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
-github.com/getAlby/ldk-node-go v0.0.0-20240508062012-79d039e31a38 h1:RiR5Z9lyxrpXAKyQH61CLbjuMcA20hGEk3b8EXJlZeU=
-github.com/getAlby/ldk-node-go v0.0.0-20240508062012-79d039e31a38/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
+github.com/getAlby/ldk-node-go v0.0.0-20240508193508-e18c07203ae1 h1:1eWAPaNWzx/iQ+a8UoUTD2bO3+9P5QXEGZ3D8kx/F7c=
+github.com/getAlby/ldk-node-go v0.0.0-20240508193508-e18c07203ae1/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/greenlight.go
+++ b/greenlight.go
@@ -111,17 +111,19 @@ func (gs *GreenlightService) Shutdown() error {
 	return nil
 }
 
-func (gs *GreenlightService) SendPaymentSync(ctx context.Context, payReq string) (preimage string, err error) {
+func (gs *GreenlightService) SendPaymentSync(ctx context.Context, payReq string) (*lnclient.Nip47PayInvoiceResponse, error) {
 	response, err := gs.client.Pay(glalby.PayRequest{
 		Bolt11: payReq,
 	})
 
 	if err != nil {
 		gs.svc.Logger.Errorf("Failed to send payment: %v", err)
-		return "", err
+		return nil, err
 	}
 	log.Printf("SendPaymentSync succeeded: %v", response.Preimage)
-	return response.Preimage, nil
+	return &lnclient.Nip47PayInvoiceResponse{
+		Preimage: response.Preimage,
+	}, nil
 }
 
 func (gs *GreenlightService) SendKeysend(ctx context.Context, amount int64, destination, preimage string, custom_records []lnclient.TLVRecord) (preImage string, err error) {

--- a/ldk.go
+++ b/ldk.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/getAlby/ldk-node-go/ldk_node"
+	// "github.com/getAlby/nostr-wallet-connect/ldk_node"
 	decodepay "github.com/nbd-wtf/ln-decodepay"
 	"github.com/sirupsen/logrus"
 
@@ -201,14 +202,14 @@ func (gs *LDKService) Shutdown() error {
 	return nil
 }
 
-func (gs *LDKService) SendPaymentSync(ctx context.Context, invoice string) (preimage string, err error) {
+func (gs *LDKService) SendPaymentSync(ctx context.Context, invoice string) (*lnclient.Nip47PayInvoiceResponse, error) {
 	paymentRequest, err := decodepay.Decodepay(invoice)
 	if err != nil {
 		gs.svc.Logger.WithFields(logrus.Fields{
 			"bolt11": invoice,
 		}).Errorf("Failed to decode bolt11 invoice: %v", err)
 
-		return "", err
+		return nil, err
 	}
 
 	maxSpendable := gs.getMaxSpendable()
@@ -231,9 +232,10 @@ func (gs *LDKService) SendPaymentSync(ctx context.Context, invoice string) (prei
 	paymentHash, err := gs.node.Bolt11Payment().Send(invoice)
 	if err != nil {
 		gs.svc.Logger.WithError(err).Error("SendPayment failed")
-		return "", err
+		return nil, err
 	}
 	fee := uint64(0)
+	preimage := ""
 
 	for start := time.Now(); time.Since(start) < time.Second*60; {
 		event := <-ldkEventSubscription
@@ -246,7 +248,7 @@ func (gs *LDKService) SendPaymentSync(ctx context.Context, invoice string) (prei
 			payment := gs.node.Payment(paymentHash)
 			if payment == nil {
 				gs.svc.Logger.Errorf("Couldn't find payment by payment hash: %v", paymentHash)
-				return "", errors.New("Payment not found")
+				return nil, errors.New("Payment not found")
 			}
 
 			bolt11PaymentKind, ok := payment.Kind.(ldk_node.PaymentKindBolt11)
@@ -259,7 +261,7 @@ func (gs *LDKService) SendPaymentSync(ctx context.Context, invoice string) (prei
 
 			if bolt11PaymentKind.Preimage == nil {
 				gs.svc.Logger.Errorf("No payment preimage for payment hash: %v", paymentHash)
-				return "", errors.New("Payment preimage not found")
+				return nil, errors.New("Payment preimage not found")
 			}
 			preimage = *bolt11PaymentKind.Preimage
 
@@ -297,19 +299,23 @@ func (gs *LDKService) SendPaymentSync(ctx context.Context, invoice string) (prei
 				"failureReasonMessage": failureReasonMessage,
 			}).Error("Received payment failed event")
 
-			return "", fmt.Errorf("received payment failed event: %v %s", failureReason, failureReasonMessage)
+			return nil, fmt.Errorf("received payment failed event: %v %s", failureReason, failureReasonMessage)
 		}
 	}
 	if preimage == "" {
 		// TODO: this doesn't necessarily mean it will fail - we should return a different response
-		return "", errors.New("Payment timed out")
+		return nil, errors.New("Payment timed out")
 	}
 
 	gs.svc.Logger.WithFields(logrus.Fields{
 		"duration": time.Since(paymentStart).Milliseconds(),
 		"fee":      fee,
 	}).Info("Successful payment")
-	return preimage, nil
+	//preimage string
+	return &lnclient.Nip47PayInvoiceResponse{
+		Preimage: preimage,
+		Fee:      &fee,
+	}, nil
 }
 
 func (gs *LDKService) SendKeysend(ctx context.Context, amount int64, destination, preimage string, custom_records []lnclient.TLVRecord) (preImage string, err error) {
@@ -520,18 +526,18 @@ func (gs *LDKService) LookupInvoice(ctx context.Context, paymentHash string) (tr
 	return transaction, nil
 }
 
-func (gs *LDKService) ListTransactions(ctx context.Context, from, until, limit, offset uint64, unpaid bool, invoiceType string) (transactions []Nip47Transaction, err error) {
+func (ls *LDKService) ListTransactions(ctx context.Context, from, until, limit, offset uint64, unpaid bool, invoiceType string) (transactions []Nip47Transaction, err error) {
 	transactions = []Nip47Transaction{}
 
 	// TODO: support pagination
-	payments := gs.node.ListPayments()
+	payments := ls.node.ListPayments()
 
 	for _, payment := range payments {
 		if payment.Status == ldk_node.PaymentStatusSucceeded || unpaid {
-			transaction, err := gs.ldkPaymentToTransaction(&payment)
+			transaction, err := ls.ldkPaymentToTransaction(&payment)
 
 			if err != nil {
-				gs.svc.Logger.Errorf("Failed to map transaction: %v", err)
+				ls.svc.Logger.Errorf("Failed to map transaction: %v", err)
 				continue
 			}
 
@@ -540,6 +546,9 @@ func (gs *LDKService) ListTransactions(ctx context.Context, from, until, limit, 
 				continue
 			}
 			if until != 0 && uint64(transaction.CreatedAt) > until {
+				continue
+			}
+			if invoiceType != "" && transaction.Type != invoiceType {
 				continue
 			}
 
@@ -563,6 +572,8 @@ func (gs *LDKService) ListTransactions(ctx context.Context, from, until, limit, 
 	if len(transactions) > int(limit) {
 		transactions = transactions[:limit]
 	}
+
+	// ls.svc.Logger.WithField("transactions", transactions).Debug("Listed transactions")
 
 	return transactions, nil
 }
@@ -764,6 +775,8 @@ func (gs *LDKService) SignMessage(ctx context.Context, message string) (string, 
 }
 
 func (gs *LDKService) ldkPaymentToTransaction(payment *ldk_node.PaymentDetails) (*Nip47Transaction, error) {
+	// gs.svc.Logger.WithField("payment", payment).Debug("Mapping LDK payment to transaction")
+
 	transactionType := "incoming"
 	if payment.Direction == ldk_node.PaymentDirectionOutbound {
 		transactionType = "outgoing"
@@ -813,14 +826,19 @@ func (gs *LDKService) ldkPaymentToTransaction(payment *ldk_node.PaymentDetails) 
 		amount = *payment.AmountMsat
 	}
 
+	var fee uint64 = 0
+	if payment.FeeMsat != nil {
+		fee = *payment.FeeMsat
+	}
+
 	return &Nip47Transaction{
-		Type:        transactionType,
-		Preimage:    preimage,
-		PaymentHash: paymentHash,
-		SettledAt:   settledAt,
-		Amount:      int64(amount),
-		Invoice:     bolt11Invoice,
-		//FeesPaid:        payment.FeeMsat,
+		Type:            transactionType,
+		Preimage:        preimage,
+		PaymentHash:     paymentHash,
+		SettledAt:       settledAt,
+		Amount:          int64(amount),
+		Invoice:         bolt11Invoice,
+		FeesPaid:        int64(fee),
 		CreatedAt:       createdAt,
 		Description:     description,
 		DescriptionHash: descriptionHash,

--- a/ldk.go
+++ b/ldk.go
@@ -311,7 +311,7 @@ func (gs *LDKService) SendPaymentSync(ctx context.Context, invoice string) (*lnc
 		"duration": time.Since(paymentStart).Milliseconds(),
 		"fee":      fee,
 	}).Info("Successful payment")
-	//preimage string
+
 	return &lnclient.Nip47PayInvoiceResponse{
 		Preimage: preimage,
 		Fee:      &fee,

--- a/ldk_event_broadcaster.go
+++ b/ldk_event_broadcaster.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/getAlby/ldk-node-go/ldk_node"
+	// "github.com/getAlby/nostr-wallet-connect/ldk_node"
 	"github.com/sirupsen/logrus"
 )
 

--- a/lnd.go
+++ b/lnd.go
@@ -193,12 +193,14 @@ func (svc *LNDService) LookupInvoice(ctx context.Context, paymentHash string) (t
 	return transaction, nil
 }
 
-func (svc *LNDService) SendPaymentSync(ctx context.Context, payReq string) (preimage string, err error) {
+func (svc *LNDService) SendPaymentSync(ctx context.Context, payReq string) (*lnclient.Nip47PayInvoiceResponse, error) {
 	resp, err := svc.client.SendPaymentSync(ctx, &lnrpc.SendRequest{PaymentRequest: payReq})
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return hex.EncodeToString(resp.PaymentPreimage), nil
+	return &lnclient.Nip47PayInvoiceResponse{
+		Preimage: hex.EncodeToString(resp.PaymentPreimage),
+	}, nil
 }
 
 func (svc *LNDService) SendKeysend(ctx context.Context, amount int64, destination, preimage string, custom_records []lnclient.TLVRecord) (respPreimage string, err error) {

--- a/models.go
+++ b/models.go
@@ -116,7 +116,8 @@ type Nip47PayParams struct {
 	Invoice string `json:"invoice"`
 }
 type Nip47PayResponse struct {
-	Preimage string `json:"preimage"`
+	Preimage string  `json:"preimage"`
+	FeesPaid *uint64 `json:"fees_paid"`
 }
 
 type Nip47MultiPayKeysendParams struct {

--- a/models/lnclient/lnclient.go
+++ b/models/lnclient/lnclient.go
@@ -19,6 +19,7 @@ type NodeInfo struct {
 	BlockHash   string
 }
 
+// TODO: use uint for fields that cannot be negative
 type Transaction struct {
 	Type            string      `json:"type"`
 	Invoice         string      `json:"invoice"`
@@ -41,7 +42,7 @@ type NodeConnectionInfo struct {
 }
 
 type LNClient interface {
-	SendPaymentSync(ctx context.Context, payReq string) (preimage string, err error)
+	SendPaymentSync(ctx context.Context, payReq string) (*Nip47PayInvoiceResponse, error)
 	SendKeysend(ctx context.Context, amount int64, destination, preimage string, customRecords []TLVRecord) (preImage string, err error)
 	GetBalance(ctx context.Context) (balance int64, err error)
 	GetInfo(ctx context.Context) (info *NodeInfo, err error)
@@ -127,6 +128,11 @@ type LightningBalanceResponse struct {
 	NextMaxReceivable    int64 `json:"nextMaxReceivable"`
 	NextMaxSpendableMPP  int64 `json:"nextMaxSpendableMPP"`
 	NextMaxReceivableMPP int64 `json:"nextMaxReceivableMPP"`
+}
+
+type Nip47PayInvoiceResponse struct {
+	Preimage string  `json:"preimage"`
+	Fee      *uint64 `json:"fee"`
 }
 
 type BalancesResponse struct {

--- a/service.go
+++ b/service.go
@@ -741,7 +741,8 @@ func (svc *Service) GetBudgetUsage(appPermission *AppPermission) int64 {
 	var result struct {
 		Sum uint
 	}
-	svc.db.Table("payments").Select("SUM(amount) as sum").Where("app_id = ? AND preimage IS NOT NULL AND created_at > ?", appPermission.AppId, GetStartOfBudget(appPermission.BudgetRenewal, appPermission.App.CreatedAt)).Scan(&result)
+	// TODO: discard failed payments from this check
+	svc.db.Table("payments").Select("SUM(amount) as sum").Where("app_id = ? AND created_at > ?", appPermission.AppId, GetStartOfBudget(appPermission.BudgetRenewal, appPermission.App.CreatedAt)).Scan(&result)
 	return int64(result.Sum)
 }
 

--- a/service_test.go
+++ b/service_test.go
@@ -1256,8 +1256,10 @@ func NewMockLn() (*MockLn, error) {
 	return &MockLn{}, nil
 }
 
-func (mln *MockLn) SendPaymentSync(ctx context.Context, payReq string) (preimage string, err error) {
-	return "123preimage", nil
+func (mln *MockLn) SendPaymentSync(ctx context.Context, payReq string) (*lnclient.Nip47PayInvoiceResponse, error) {
+	return &lnclient.Nip47PayInvoiceResponse{
+		Preimage: "123preimage",
+	}, nil
 }
 
 func (mln *MockLn) SendKeysend(ctx context.Context, amount int64, destination, preimage string, custom_records []lnclient.TLVRecord) (preImage string, err error) {


### PR DESCRIPTION
TODO:
- [x] consume ldk-node-go with mac bindings

This adds fees for the LDK node type to:
- pay_invoice
- list_transactions
- lookup_invoice

It also removes the preimage check in the budget calculation as a small step towards https://github.com/getAlby/nostr-wallet-connect-next/issues/279

the ldk-node-go update also penalizes routes with longer hops, resulting in more reliable payments