### PR TITLE
fix: LDK shutdown

### DIFF
--- a/api.go
+++ b/api.go
@@ -398,13 +398,19 @@ func (api *API) OpenChannel(ctx context.Context, openChannelRequest *models.Open
 	return api.svc.lnClient.OpenChannel(ctx, openChannelRequest)
 }
 
-func (api *API) CloseChannel(ctx context.Context, peerId, channelId string) (*models.CloseChannelResponse, error) {
+func (api *API) CloseChannel(ctx context.Context, peerId, channelId string, force bool) (*models.CloseChannelResponse, error) {
 	if api.svc.lnClient == nil {
 		return nil, errors.New("LNClient not started")
 	}
+	api.svc.Logger.WithFields(logrus.Fields{
+		"peer_id":    peerId,
+		"channel_id": channelId,
+		"force":      force,
+	}).Info("Closing channel")
 	return api.svc.lnClient.CloseChannel(ctx, &lnclient.CloseChannelRequest{
 		NodeId:    peerId,
 		ChannelId: channelId,
+		Force:     force,
 	})
 }
 

--- a/frontend/src/screens/settings/DebugTools.tsx
+++ b/frontend/src/screens/settings/DebugTools.tsx
@@ -99,6 +99,13 @@ export default function DebugTools() {
         >
           Get Node Status
         </Button>
+        <Button
+          onClick={() => {
+            apiRequest(`/api/balances`, "GET");
+          }}
+        >
+          Get Balances
+        </Button>
       </div>
       {apiResponse && (
         <Textarea

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/breez/breez-sdk-go v0.3.4
 	github.com/davrux/echo-logrus/v4 v4.0.3
 	github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8
-	github.com/getAlby/ldk-node-go v0.0.0-20240509190335-2fd594b1b4c6
+	github.com/getAlby/ldk-node-go v0.0.0-20240515073516-379321f32875
 	github.com/go-gormigrate/gormigrate/v2 v2.1.1
 	github.com/gorilla/sessions v1.2.2
 	github.com/labstack/echo-contrib v0.14.1

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/breez/breez-sdk-go v0.3.4
 	github.com/davrux/echo-logrus/v4 v4.0.3
 	github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8
-	github.com/getAlby/ldk-node-go v0.0.0-20240515073516-379321f32875
+	github.com/getAlby/ldk-node-go v0.0.0-20240515131517-fde35422939d
 	github.com/go-gormigrate/gormigrate/v2 v2.1.1
 	github.com/gorilla/sessions v1.2.2
 	github.com/labstack/echo-contrib v0.14.1

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/breez/breez-sdk-go v0.3.4
 	github.com/davrux/echo-logrus/v4 v4.0.3
 	github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8
-	github.com/getAlby/ldk-node-go v0.0.0-20240515131517-fde35422939d
+	github.com/getAlby/ldk-node-go v0.0.0-20240515160849-d736a0549b39
 	github.com/go-gormigrate/gormigrate/v2 v2.1.1
 	github.com/gorilla/sessions v1.2.2
 	github.com/labstack/echo-contrib v0.14.1

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/breez/breez-sdk-go v0.3.4
 	github.com/davrux/echo-logrus/v4 v4.0.3
 	github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8
-	github.com/getAlby/ldk-node-go v0.0.0-20240515160849-d736a0549b39
+	github.com/getAlby/ldk-node-go v0.0.0-20240509190335-2fd594b1b4c6
 	github.com/go-gormigrate/gormigrate/v2 v2.1.1
 	github.com/gorilla/sessions v1.2.2
 	github.com/labstack/echo-contrib v0.14.1

--- a/go.sum
+++ b/go.sum
@@ -236,6 +236,8 @@ github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8 h1:mJsdhUb8hmSSS
 github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8/go.mod h1:ViyJvjlvv0GCesTJ7mb3fBo4G+/qsujDAFN90xZ7a9U=
 github.com/getAlby/ldk-node-go v0.0.0-20240509190335-2fd594b1b4c6 h1:z/JNAllL3/fRPdxM5iJOmICb6+d/9koaTBeHFTmT3Xk=
 github.com/getAlby/ldk-node-go v0.0.0-20240509190335-2fd594b1b4c6/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
+github.com/getAlby/ldk-node-go v0.0.0-20240515073516-379321f32875 h1:oYZ8kqg7jAF1iYJ7W7/WDcEbrtfGc6v5rYc+SXSt37Y=
+github.com/getAlby/ldk-node-go v0.0.0-20240515073516-379321f32875/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/go.sum
+++ b/go.sum
@@ -236,12 +236,6 @@ github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8 h1:mJsdhUb8hmSSS
 github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8/go.mod h1:ViyJvjlvv0GCesTJ7mb3fBo4G+/qsujDAFN90xZ7a9U=
 github.com/getAlby/ldk-node-go v0.0.0-20240509190335-2fd594b1b4c6 h1:z/JNAllL3/fRPdxM5iJOmICb6+d/9koaTBeHFTmT3Xk=
 github.com/getAlby/ldk-node-go v0.0.0-20240509190335-2fd594b1b4c6/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
-github.com/getAlby/ldk-node-go v0.0.0-20240515073516-379321f32875 h1:oYZ8kqg7jAF1iYJ7W7/WDcEbrtfGc6v5rYc+SXSt37Y=
-github.com/getAlby/ldk-node-go v0.0.0-20240515073516-379321f32875/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
-github.com/getAlby/ldk-node-go v0.0.0-20240515131517-fde35422939d h1:8egXobWV/KWyvmB1pi2gwwq6oXeQJ5Kb26wJYocuBXo=
-github.com/getAlby/ldk-node-go v0.0.0-20240515131517-fde35422939d/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
-github.com/getAlby/ldk-node-go v0.0.0-20240515160849-d736a0549b39 h1:3+Wqk/XimXzp2/l4Zo7UabqGKnOk535+9qfYwYshBK0=
-github.com/getAlby/ldk-node-go v0.0.0-20240515160849-d736a0549b39/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -1349,8 +1343,6 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gorm.io/gorm v1.25.7 h1:VsD6acwRjz2zFxGO50gPO6AkNs7KKnvfzUjHQhZDz/A=
-gorm.io/gorm v1.25.7/go.mod h1:hbnx/Oo0ChWMn1BIhpy1oYozzpM15i4YPuHDmfYtwg8=
 gorm.io/gorm v1.25.10 h1:dQpO+33KalOA+aFYGlK+EfxcI5MbO7EP2yYygwh9h+s=
 gorm.io/gorm v1.25.10/go.mod h1:hbnx/Oo0ChWMn1BIhpy1oYozzpM15i4YPuHDmfYtwg8=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=

--- a/go.sum
+++ b/go.sum
@@ -238,6 +238,8 @@ github.com/getAlby/ldk-node-go v0.0.0-20240509190335-2fd594b1b4c6 h1:z/JNAllL3/f
 github.com/getAlby/ldk-node-go v0.0.0-20240509190335-2fd594b1b4c6/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/getAlby/ldk-node-go v0.0.0-20240515073516-379321f32875 h1:oYZ8kqg7jAF1iYJ7W7/WDcEbrtfGc6v5rYc+SXSt37Y=
 github.com/getAlby/ldk-node-go v0.0.0-20240515073516-379321f32875/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
+github.com/getAlby/ldk-node-go v0.0.0-20240515131517-fde35422939d h1:8egXobWV/KWyvmB1pi2gwwq6oXeQJ5Kb26wJYocuBXo=
+github.com/getAlby/ldk-node-go v0.0.0-20240515131517-fde35422939d/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/go.sum
+++ b/go.sum
@@ -240,6 +240,8 @@ github.com/getAlby/ldk-node-go v0.0.0-20240515073516-379321f32875 h1:oYZ8kqg7jAF
 github.com/getAlby/ldk-node-go v0.0.0-20240515073516-379321f32875/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/getAlby/ldk-node-go v0.0.0-20240515131517-fde35422939d h1:8egXobWV/KWyvmB1pi2gwwq6oXeQJ5Kb26wJYocuBXo=
 github.com/getAlby/ldk-node-go v0.0.0-20240515131517-fde35422939d/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
+github.com/getAlby/ldk-node-go v0.0.0-20240515160849-d736a0549b39 h1:3+Wqk/XimXzp2/l4Zo7UabqGKnOk535+9qfYwYshBK0=
+github.com/getAlby/ldk-node-go v0.0.0-20240515160849-d736a0549b39/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/http_service.go
+++ b/http_service.go
@@ -443,7 +443,7 @@ func (httpSvc *HttpService) openChannelHandler(c echo.Context) error {
 func (httpSvc *HttpService) closeChannelHandler(c echo.Context) error {
 	ctx := c.Request().Context()
 
-	closeChannelResponse, err := httpSvc.api.CloseChannel(ctx, c.Param("peerId"), c.Param("channelId"))
+	closeChannelResponse, err := httpSvc.api.CloseChannel(ctx, c.Param("peerId"), c.Param("channelId"), c.QueryParam("force") == "true")
 
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, models.ErrorResponse{

--- a/ldk.go
+++ b/ldk.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"log"
@@ -33,6 +34,8 @@ type LDKService struct {
 	network             string
 	eventPublisher      events.EventPublisher
 }
+
+const resetRouterKey = "ResetRouter"
 
 func NewLDKService(ctx context.Context, svc *Service, mnemonic, workDir string, network string, esploraServer string, gossipSource string) (result lnclient.LNClient, err error) {
 	if mnemonic == "" || workDir == "" {
@@ -195,22 +198,103 @@ func NewLDKService(ctx context.Context, svc *Service, mnemonic, workDir string, 
 	return &ls, nil
 }
 
-func (gs *LDKService) Shutdown() error {
-	gs.svc.Logger.Infof("shutting down LDK client")
-	gs.svc.Logger.Infof("cancelling LDK context")
-	gs.cancel()
-	/*gs.svc.Logger.Infof("stopping LDK node")
-	err := gs.node.Stop()
-	if err != nil {
-		gs.svc.Logger.WithError(err).Error("Failed to stop LDK node")
-		return err
-	}*/
-	gs.svc.Logger.Infof("Destroying node")
-	gs.node.Destroy()
+func (ls *LDKService) Shutdown() error {
+	if ls.node == nil {
+		ls.svc.Logger.Infof("LDK client already shut down")
+		return nil
+	}
+	// make sure nothing else can use it
+	node := ls.node
+	ls.node = nil
 
-	gs.svc.Logger.Infof("LDK shutdown complete")
+	ls.svc.Logger.Infof("shutting down LDK client")
+	ls.svc.Logger.Infof("cancelling LDK context")
+	ls.cancel()
+
+	ls.svc.Logger.Infof("stopping LDK node")
+	shutdownChannel := make(chan error)
+	go func() {
+		shutdownChannel <- node.Stop()
+	}()
+
+	select {
+	case err := <-shutdownChannel:
+		if err != nil {
+			ls.svc.Logger.WithError(err).Error("Failed to stop LDK node")
+			// do not return error - we still need to destroy the node
+		} else {
+			ls.svc.Logger.Info("LDK stop node succeeded")
+		}
+	case <-time.After(10 * time.Second):
+		ls.svc.Logger.Error("Timeout shutting down LDK node after 10 seconds")
+	}
+
+	ls.svc.Logger.Infof("Destroying node object")
+	node.Destroy()
+
+	ls.resetRouterInternal()
+
+	ls.svc.Logger.Infof("LDK shutdown complete")
 
 	return nil
+}
+
+func (ls *LDKService) resetRouterInternal() {
+	key, err := ls.svc.cfg.Get(resetRouterKey, "")
+
+	if err != nil {
+		ls.svc.Logger.Error("Failed to retrieve ResetRouter key")
+	}
+
+	if key != "" {
+		ls.svc.cfg.SetUpdate(resetRouterKey, "", "")
+		ls.svc.Logger.WithField("key", key).Info("Resetting router")
+
+		ldkDbPath := filepath.Join(ls.workdir, "storage", "ldk_node_data.sqlite")
+		if _, err := os.Stat(ldkDbPath); errors.Is(err, os.ErrNotExist) {
+			ls.svc.Logger.Error("Could not find LDK database")
+			return
+		}
+		ldkDb, err := sql.Open("sqlite", ldkDbPath)
+		if err != nil {
+			ls.svc.Logger.Error("Could not open LDK DB file")
+			return
+		}
+
+		command := ""
+
+		switch key {
+		case "ALL":
+			command = "delete from ldk_node_data where key = 'latest_rgs_sync_timestamp' or key = 'scorer' or key = 'network_graph';"
+		case "LatestRgsSyncTimestamp":
+			command = "delete from ldk_node_data where key = 'latest_rgs_sync_timestamp';"
+		case "Scorer":
+			command = "delete from ldk_node_data where key = 'scorer';"
+		case "NetworkGraph":
+			command = "delete from ldk_node_data where key = 'network_graph';"
+		default:
+			ls.svc.Logger.WithField("key", key).Error("Unknown reset router key")
+			return
+		}
+
+		result, err := ldkDb.Exec(command)
+		if err != nil {
+			ls.svc.Logger.WithError(err).Error("Failed execute reset command")
+			return
+		}
+		rowsAffected, err := result.RowsAffected()
+		if err != nil {
+			ls.svc.Logger.WithError(err).Error("Failed to get rows affected")
+			return
+		}
+		ls.svc.Logger.WithFields(logrus.Fields{
+			"rowsAffected": rowsAffected,
+		}).Info("Reset router")
+
+		if err != nil {
+			ls.svc.Logger.WithField("key", key).WithError(err).Error("ResetRouter failed")
+		}
+	}
 }
 
 func (gs *LDKService) SendPaymentSync(ctx context.Context, invoice string) (*lnclient.Nip47PayInvoiceResponse, error) {
@@ -766,31 +850,9 @@ func (gs *LDKService) RedeemOnchainFunds(ctx context.Context, toAddress string) 
 }
 
 func (ls *LDKService) ResetRouter(ctx context.Context, key string) error {
-	// HACK: to ensure the router is reset correctly we must stop the node first.
-	err := ls.node.Stop()
-	if err != nil {
-		ls.svc.Logger.WithError(err).Error("Failed to stop the node")
-	}
+	ls.svc.cfg.SetUpdate(resetRouterKey, key, "")
 
-	switch key {
-	case "":
-		fallthrough
-	case "ALL":
-		err = ls.node.ResetRouter()
-	case "LatestRgsSyncTimestamp":
-		err = ls.node.ResetRouterRecord(ldk_node.PersistentRecordKeyLatestRgsSyncTimestamp)
-	case "Scorer":
-		err = ls.node.ResetRouterRecord(ldk_node.PersistentRecordKeyScorer)
-	case "NetworkGraph":
-		err = ls.node.ResetRouterRecord(ldk_node.PersistentRecordKeyNetworkGraph)
-	default:
-		err = fmt.Errorf("unknown key: %s", key)
-	}
-	if err != nil {
-		ls.svc.Logger.WithField("key", key).WithError(err).Error("ResetRouter failed")
-	}
-
-	return err
+	return nil
 }
 
 func (gs *LDKService) SignMessage(ctx context.Context, message string) (string, error) {

--- a/ldk.go
+++ b/ldk.go
@@ -225,8 +225,8 @@ func (ls *LDKService) Shutdown() error {
 		} else {
 			ls.svc.Logger.Info("LDK stop node succeeded")
 		}
-	case <-time.After(10 * time.Second):
-		ls.svc.Logger.Error("Timeout shutting down LDK node after 10 seconds")
+	case <-time.After(30 * time.Second):
+		ls.svc.Logger.Error("Timeout shutting down LDK node after 30 seconds")
 	}
 
 	ls.svc.Logger.Infof("Destroying node object")

--- a/ldk.go
+++ b/ldk.go
@@ -265,13 +265,13 @@ func (ls *LDKService) resetRouterInternal() {
 
 		switch key {
 		case "ALL":
-			command = "delete from ldk_node_data where key = 'latest_rgs_sync_timestamp' or key = 'scorer' or key = 'network_graph';"
+			command = "delete from ldk_node_data where key = 'latest_rgs_sync_timestamp' or key = 'scorer' or key = 'network_graph';VACUUM;"
 		case "LatestRgsSyncTimestamp":
-			command = "delete from ldk_node_data where key = 'latest_rgs_sync_timestamp';"
+			command = "delete from ldk_node_data where key = 'latest_rgs_sync_timestamp';VACUUM;"
 		case "Scorer":
-			command = "delete from ldk_node_data where key = 'scorer';"
+			command = "delete from ldk_node_data where key = 'scorer';VACUUM;"
 		case "NetworkGraph":
-			command = "delete from ldk_node_data where key = 'network_graph';"
+			command = "delete from ldk_node_data where key = 'network_graph';VACUUM;"
 		default:
 			ls.svc.Logger.WithField("key", key).Error("Unknown reset router key")
 			return

--- a/ldk.go
+++ b/ldk.go
@@ -811,7 +811,7 @@ func (gs *LDKService) CloseChannel(ctx context.Context, closeChannelRequest *lnc
 		"request": closeChannelRequest,
 	}).Info("Closing Channel")
 	// TODO: support passing force option
-	err := gs.node.CloseChannel(closeChannelRequest.ChannelId, closeChannelRequest.NodeId, false)
+	err := gs.node.CloseChannel(closeChannelRequest.ChannelId, closeChannelRequest.NodeId, closeChannelRequest.Force)
 	if err != nil {
 		gs.svc.Logger.WithError(err).Error("CloseChannel failed")
 		return nil, err

--- a/main_http.go
+++ b/main_http.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"syscall"
 	"time"
 
 	echologrus "github.com/davrux/echo-logrus/v4"
@@ -22,7 +23,7 @@ import (
 // this function will only be executed if no wails tag is set
 func main() {
 	log.Info("NWC Starting in HTTP mode")
-	ctx, _ := signal.NotifyContext(context.Background(), os.Interrupt)
+	ctx, _ := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM, os.Kill)
 	svc, _ := NewService(ctx)
 
 	echologrus.Logger = svc.Logger

--- a/models/lnclient/lnclient.go
+++ b/models/lnclient/lnclient.go
@@ -105,6 +105,7 @@ type OpenChannelResponse struct {
 type CloseChannelRequest struct {
 	ChannelId string `json:"channelId"`
 	NodeId    string `json:"nodeId"`
+	Force     bool   `json:"force"`
 }
 
 type CloseChannelResponse struct {

--- a/wails_handlers.go
+++ b/wails_handlers.go
@@ -92,23 +92,26 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 	}
 
 	peerChannelRegex := regexp.MustCompile(
-		`/api/peers/([^/]+)/channels/([^/]+)`,
+		`/api/peers/([^/]+)/channels/([^/]+)\?force=.+`,
 	)
 
 	peerChannelMatch := peerChannelRegex.FindStringSubmatch(route)
 
 	switch {
-	case len(peerChannelMatch) > 1:
+	case len(peerChannelMatch) == 3:
 		peerId := peerChannelMatch[1]
 		channelId := peerChannelMatch[2]
+		force := peerChannelMatch[3]
 		switch method {
 		case "DELETE":
-			closeChannelResponse, err := app.api.CloseChannel(ctx, peerId, channelId)
+			closeChannelResponse, err := app.api.CloseChannel(ctx, peerId, channelId, force == "true")
 			if err != nil {
 				return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 			}
 			return WailsRequestRouterResponse{Body: closeChannelResponse, Error: ""}
 		}
+	default:
+		return WailsRequestRouterResponse{Body: nil, Error: "could not parse delete channel request"}
 	}
 
 	mempoolApiRegex := regexp.MustCompile(


### PR DESCRIPTION
- add force close channel option
- remove reference to LDK node at start of shutdown so it cannot be interacted with
- call LDK stop with 30 second timeout
- move reset router logic to Go after LDK node is shut down
- add button to debug tools to get balances
- update ldk-node to latest changes on tnull's anchor support branch

TODOs:
- [x] check deadlock is fixed
- [x] check graceful shutdown on fly update
- [ ] wallet sync is working again (currently times out) - moved to separate issue
- [ ] update LDK-node to work on all environments - moved to separate issue