### PR TITLE
feat: reset router when backing up node, update ldk-node dependency

### DIFF
--- a/breez.go
+++ b/breez.go
@@ -399,7 +399,7 @@ func (bs *BreezService) RedeemOnchainFunds(ctx context.Context, toAddress string
 	return hex.EncodeToString(redeemOnchainFundsResponse.Txid), nil
 }
 
-func (bs *BreezService) ResetRouter(ctx context.Context, key string) error {
+func (bs *BreezService) ResetRouter(key string) error {
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/breez/breez-sdk-go v0.3.4
 	github.com/davrux/echo-logrus/v4 v4.0.3
 	github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8
-	github.com/getAlby/ldk-node-go v0.0.0-20240509190335-2fd594b1b4c6
+	github.com/getAlby/ldk-node-go v0.0.0-20240515190623-a442ff83ea3f
 	github.com/go-gormigrate/gormigrate/v2 v2.1.1
 	github.com/gorilla/sessions v1.2.2
 	github.com/labstack/echo-contrib v0.14.1

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/breez/breez-sdk-go v0.3.4
 	github.com/davrux/echo-logrus/v4 v4.0.3
 	github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8
-	github.com/getAlby/ldk-node-go v0.0.0-20240516104243-53a25488ccbb
+	github.com/getAlby/ldk-node-go v0.0.0-20240516162602-db3ce7fedb76
 	github.com/go-gormigrate/gormigrate/v2 v2.1.1
 	github.com/gorilla/sessions v1.2.2
 	github.com/labstack/echo-contrib v0.14.1

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/breez/breez-sdk-go v0.3.4
 	github.com/davrux/echo-logrus/v4 v4.0.3
 	github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8
-	github.com/getAlby/ldk-node-go v0.0.0-20240515190623-a442ff83ea3f
+	github.com/getAlby/ldk-node-go v0.0.0-20240516104243-53a25488ccbb
 	github.com/go-gormigrate/gormigrate/v2 v2.1.1
 	github.com/gorilla/sessions v1.2.2
 	github.com/labstack/echo-contrib v0.14.1

--- a/go.sum
+++ b/go.sum
@@ -240,6 +240,8 @@ github.com/getAlby/ldk-node-go v0.0.0-20240515190623-a442ff83ea3f h1:asTRJSqAjaK
 github.com/getAlby/ldk-node-go v0.0.0-20240515190623-a442ff83ea3f/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/getAlby/ldk-node-go v0.0.0-20240516104243-53a25488ccbb h1:DnfAFqq7lMv7LPc3RkeQEEqlnFyrw9DI2Y+NgnguYEo=
 github.com/getAlby/ldk-node-go v0.0.0-20240516104243-53a25488ccbb/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
+github.com/getAlby/ldk-node-go v0.0.0-20240516162602-db3ce7fedb76 h1:MvnTVh7exBC3dNn7kXsbFLUZgDfE9lf7MenL9KrVPpw=
+github.com/getAlby/ldk-node-go v0.0.0-20240516162602-db3ce7fedb76/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/go.sum
+++ b/go.sum
@@ -236,6 +236,8 @@ github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8 h1:mJsdhUb8hmSSS
 github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8/go.mod h1:ViyJvjlvv0GCesTJ7mb3fBo4G+/qsujDAFN90xZ7a9U=
 github.com/getAlby/ldk-node-go v0.0.0-20240509190335-2fd594b1b4c6 h1:z/JNAllL3/fRPdxM5iJOmICb6+d/9koaTBeHFTmT3Xk=
 github.com/getAlby/ldk-node-go v0.0.0-20240509190335-2fd594b1b4c6/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
+github.com/getAlby/ldk-node-go v0.0.0-20240515190623-a442ff83ea3f h1:asTRJSqAjaKOXWZJT2xb3F6C+yFhnzjo36JJ77vzYag=
+github.com/getAlby/ldk-node-go v0.0.0-20240515190623-a442ff83ea3f/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/go.sum
+++ b/go.sum
@@ -234,12 +234,6 @@ github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8 h1:mJsdhUb8hmSSSLR2GQFw9BGtnJP7xmKB/XQxDt3DvAo=
 github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8/go.mod h1:ViyJvjlvv0GCesTJ7mb3fBo4G+/qsujDAFN90xZ7a9U=
-github.com/getAlby/ldk-node-go v0.0.0-20240509190335-2fd594b1b4c6 h1:z/JNAllL3/fRPdxM5iJOmICb6+d/9koaTBeHFTmT3Xk=
-github.com/getAlby/ldk-node-go v0.0.0-20240509190335-2fd594b1b4c6/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
-github.com/getAlby/ldk-node-go v0.0.0-20240515190623-a442ff83ea3f h1:asTRJSqAjaKOXWZJT2xb3F6C+yFhnzjo36JJ77vzYag=
-github.com/getAlby/ldk-node-go v0.0.0-20240515190623-a442ff83ea3f/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
-github.com/getAlby/ldk-node-go v0.0.0-20240516104243-53a25488ccbb h1:DnfAFqq7lMv7LPc3RkeQEEqlnFyrw9DI2Y+NgnguYEo=
-github.com/getAlby/ldk-node-go v0.0.0-20240516104243-53a25488ccbb/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/getAlby/ldk-node-go v0.0.0-20240516162602-db3ce7fedb76 h1:MvnTVh7exBC3dNn7kXsbFLUZgDfE9lf7MenL9KrVPpw=
 github.com/getAlby/ldk-node-go v0.0.0-20240516162602-db3ce7fedb76/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=

--- a/go.sum
+++ b/go.sum
@@ -238,6 +238,8 @@ github.com/getAlby/ldk-node-go v0.0.0-20240509190335-2fd594b1b4c6 h1:z/JNAllL3/f
 github.com/getAlby/ldk-node-go v0.0.0-20240509190335-2fd594b1b4c6/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/getAlby/ldk-node-go v0.0.0-20240515190623-a442ff83ea3f h1:asTRJSqAjaKOXWZJT2xb3F6C+yFhnzjo36JJ77vzYag=
 github.com/getAlby/ldk-node-go v0.0.0-20240515190623-a442ff83ea3f/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
+github.com/getAlby/ldk-node-go v0.0.0-20240516104243-53a25488ccbb h1:DnfAFqq7lMv7LPc3RkeQEEqlnFyrw9DI2Y+NgnguYEo=
+github.com/getAlby/ldk-node-go v0.0.0-20240516104243-53a25488ccbb/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/greenlight.go
+++ b/greenlight.go
@@ -596,7 +596,7 @@ func (gs *GreenlightService) greenlightInvoiceToTransaction(invoice *glalby.List
 	return transaction, nil
 }
 
-func (gs *GreenlightService) ResetRouter(ctx context.Context, key string) error {
+func (gs *GreenlightService) ResetRouter(key string) error {
 	return nil
 }
 

--- a/http_service.go
+++ b/http_service.go
@@ -300,9 +300,7 @@ func (httpSvc *HttpService) resetRouterHandler(c echo.Context) error {
 		})
 	}
 
-	ctx := c.Request().Context()
-
-	err := httpSvc.api.ResetRouter(ctx, resetRouterRequest.Key)
+	err := httpSvc.api.ResetRouter(resetRouterRequest.Key, true)
 
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, models.ErrorResponse{

--- a/ldk.go
+++ b/ldk.go
@@ -849,7 +849,7 @@ func (gs *LDKService) RedeemOnchainFunds(ctx context.Context, toAddress string) 
 	return txId, nil
 }
 
-func (ls *LDKService) ResetRouter(ctx context.Context, key string) error {
+func (ls *LDKService) ResetRouter(key string) error {
 	ls.svc.cfg.SetUpdate(resetRouterKey, key, "")
 
 	return nil

--- a/lnd.go
+++ b/lnd.go
@@ -436,7 +436,7 @@ func lndInvoiceToTransaction(invoice *lnrpc.Invoice) *Nip47Transaction {
 	}
 }
 
-func (svc *LNDService) ResetRouter(ctx context.Context, key string) error {
+func (svc *LNDService) ResetRouter(key string) error {
 	return nil
 }
 

--- a/models/lnclient/lnclient.go
+++ b/models/lnclient/lnclient.go
@@ -57,7 +57,7 @@ type LNClient interface {
 	OpenChannel(ctx context.Context, openChannelRequest *OpenChannelRequest) (*OpenChannelResponse, error)
 	CloseChannel(ctx context.Context, closeChannelRequest *CloseChannelRequest) (*CloseChannelResponse, error)
 	GetNewOnchainAddress(ctx context.Context) (string, error)
-	ResetRouter(ctx context.Context, key string) error
+	ResetRouter(key string) error
 	GetOnchainBalance(ctx context.Context) (*OnchainBalanceResponse, error)
 	GetBalances(ctx context.Context) (*BalancesResponse, error)
 	RedeemOnchainFunds(ctx context.Context, toAddress string) (txId string, err error)

--- a/service_test.go
+++ b/service_test.go
@@ -1316,7 +1316,7 @@ func (mln *MockLn) GetOnchainBalance(ctx context.Context) (*lnclient.OnchainBala
 func (mln *MockLn) RedeemOnchainFunds(ctx context.Context, toAddress string) (txId string, err error) {
 	return "", nil
 }
-func (mln *MockLn) ResetRouter(ctx context.Context, key string) error {
+func (mln *MockLn) ResetRouter(key string) error {
 	return nil
 }
 func (mln *MockLn) SendPaymentProbes(ctx context.Context, invoice string) error {

--- a/wails_handlers.go
+++ b/wails_handlers.go
@@ -208,7 +208,7 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 		}
 
-		err = app.api.ResetRouter(ctx, resetRouterRequest.Key)
+		err = app.api.ResetRouter(resetRouterRequest.Key, true)
 		if err != nil {
 			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 		}


### PR DESCRIPTION
Fixes https://github.com/getAlby/nostr-wallet-connect-next/issues/316
Fixes https://github.com/getAlby/nostr-wallet-connect-next/issues/315

The LDK-node updates make shutdown more likely to finish safely, reduce chance of blocking/deadlocks while sync is running, and increase some sync timeouts to ensure the sync finishes as much as possible.

The router reset is done to reduce the size of the ldk node DB, and the router data is not essential which can be re-calculated once the node is started again.