### PR TITLE
feat: connect some peers at LDK node startup for p2p gossip

### DIFF
--- a/ldk.go
+++ b/ldk.go
@@ -196,7 +196,7 @@ func NewLDKService(ctx context.Context, svc *Service, mnemonic, workDir string, 
 	}
 
 	if ls.network == "bitcoin" {
-		// try to connect to some peers to retrieve P2P gossip data
+		// try to connect to some peers to retrieve P2P gossip data. TODO: Remove once LDK can correctly do gossip with CLN and Eclair nodes
 		peers := []string{
 			"031b301307574bbe9b9ac7b79cbe1700e31e544513eae0b5d7497483083f99e581@45.79.192.236:9735",   // Olympus
 			"0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1@192.243.215.102:9735", // LQwD

--- a/ldk.go
+++ b/ldk.go
@@ -195,6 +195,33 @@ func NewLDKService(ctx context.Context, svc *Service, mnemonic, workDir string, 
 		time.Sleep(1 * time.Second)
 	}
 
+	if ls.network == "bitcoin" {
+		// try to connect to some peers to retrieve P2P gossip data
+		peers := []string{
+			"031b301307574bbe9b9ac7b79cbe1700e31e544513eae0b5d7497483083f99e581@45.79.192.236:9735",   // Olympus
+			"0364913d18a19c671bb36dd04d6ad5be0fe8f2894314c36a9db3f03c2d414907e1@192.243.215.102:9735", // LQwD
+			"035e4ff418fc8b5554c5d9eea66396c227bd429a3251c8cbc711002ba215bfc226@170.75.163.209:9735",  // WoS
+			"02fcc5bfc48e83f06c04483a2985e1c390cb0f35058baa875ad2053858b8e80dbd@35.239.148.251:9735",  // Blink
+		}
+		svc.Logger.Info("Connecting to some peers to retrieve P2P gossip data")
+		for _, peer := range peers {
+			parts := strings.FieldsFunc(peer, func(r rune) bool { return r == '@' || r == ':' })
+			port, err := strconv.ParseUint(parts[2], 10, 16)
+			if err != nil {
+				svc.Logger.WithError(err).Error("Failed to parse port number")
+				continue
+			}
+			err = ls.ConnectPeer(ctx, &lnclient.ConnectPeerRequest{
+				Pubkey:  parts[0],
+				Address: parts[1],
+				Port:    uint16(port),
+			})
+			if err != nil {
+				svc.Logger.WithField("peer", peer).WithError(err).Error("Failed to connect to peer")
+			}
+		}
+	}
+
 	return &ls, nil
 }
 


### PR DESCRIPTION
Existing node info could not be used because we only store pubkeys. This list will need to be maintained and I'm not sure we can do this long term. Update: this is probably only needed until LDK p2p gossip interoperability with CLN and Eclair is fixed.