### PR TITLE
feat: dynamic wallet sync intervals based on user activity

### DIFF
--- a/api.go
+++ b/api.go
@@ -1248,6 +1248,10 @@ func (api *API) GetNetworkGraph(nodeIds []string) (models.NetworkGraphResponse, 
 	return api.svc.lnClient.GetNetworkGraph(nodeIds)
 }
 
+func (api *API) RequestWalletSync() {
+	api.svc.lastWalletSyncRequest = time.Now()
+}
+
 func (api *API) GetLogOutput(ctx context.Context, logType string, getLogRequest *models.GetLogOutputRequest) (*models.GetLogOutputResponse, error) {
 	var err error
 	var logData []byte

--- a/api.go
+++ b/api.go
@@ -1248,7 +1248,7 @@ func (api *API) GetNetworkGraph(nodeIds []string) (models.NetworkGraphResponse, 
 	return api.svc.lnClient.GetNetworkGraph(nodeIds)
 }
 
-func (api *API) RequestWalletSync() {
+func (api *API) SyncWallet() {
 	api.svc.lastWalletSyncRequest = time.Now()
 }
 

--- a/frontend/src/hooks/useSyncWallet.ts
+++ b/frontend/src/hooks/useSyncWallet.ts
@@ -1,0 +1,34 @@
+import React from "react";
+import { useCSRF } from "src/hooks/useCSRF";
+import { request } from "src/utils/request";
+
+export function useSyncWallet() {
+  const { data: csrf } = useCSRF();
+  const REQUEST_WALLET_SYNC_INTERVAL = 30_000; // request a wallet sync every 30s (NOTE: it won't actually sync this often)
+
+  React.useEffect(() => {
+    if (!csrf) {
+      return;
+    }
+
+    const intervalId = setInterval(async () => {
+      try {
+        await request("/api/request-wallet-sync", {
+          method: "POST",
+          headers: {
+            "X-CSRF-Token": csrf,
+            "Content-Type": "application/json",
+          },
+        });
+      } catch (error) {
+        console.error("failed to request wallet sync", error);
+      }
+    }, REQUEST_WALLET_SYNC_INTERVAL);
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [csrf]);
+
+  return null;
+}

--- a/frontend/src/hooks/useSyncWallet.ts
+++ b/frontend/src/hooks/useSyncWallet.ts
@@ -13,7 +13,7 @@ export function useSyncWallet() {
 
     const intervalId = setInterval(async () => {
       try {
-        await request("/api/request-wallet-sync", {
+        await request("/api/wallet/sync", {
           method: "POST",
           headers: {
             "X-CSRF-Token": csrf,

--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -48,6 +48,7 @@ import { useChannels } from "src/hooks/useChannels";
 import { useInfo } from "src/hooks/useInfo";
 import { useNodeConnectionInfo } from "src/hooks/useNodeConnectionInfo.ts";
 import { useRedeemOnchainFunds } from "src/hooks/useRedeemOnchainFunds.ts";
+import { useSyncWallet } from "src/hooks/useSyncWallet.ts";
 import { copyToClipboard } from "src/lib/clipboard.ts";
 import { formatAmount } from "src/lib/utils.ts";
 import { CloseChannelResponse, Node } from "src/types";
@@ -55,6 +56,7 @@ import { request } from "src/utils/request";
 import { useCSRF } from "../../hooks/useCSRF.ts";
 
 export default function Channels() {
+  useSyncWallet();
   const { data: channels, mutate: reloadChannels } = useChannels();
   const { data: nodeConnectionInfo } = useNodeConnectionInfo();
   const { data: balances } = useBalances();

--- a/frontend/src/screens/channels/CurrentChannelOrder.tsx
+++ b/frontend/src/screens/channels/CurrentChannelOrder.tsx
@@ -48,6 +48,7 @@ import { useBalances } from "src/hooks/useBalances";
 import { useCSRF } from "src/hooks/useCSRF";
 import { useChannels } from "src/hooks/useChannels";
 import { useMempoolApi } from "src/hooks/useMempoolApi";
+import { useSyncWallet } from "src/hooks/useSyncWallet";
 import { copyToClipboard } from "src/lib/clipboard";
 import { Success } from "src/screens/onboarding/Success";
 import useChannelOrderStore from "src/state/ChannelOrderStore";
@@ -76,6 +77,7 @@ export function CurrentChannelOrder() {
 }
 
 function ChannelOrderInternal({ order }: { order: NewChannelOrder }) {
+  useSyncWallet();
   switch (order.status) {
     case "pay":
       switch (order.paymentMethod) {
@@ -358,12 +360,12 @@ function PayBitcoinChannelOrderTopup({ order }: { order: NewChannelOrder }) {
               be redirected as soon as the transaction is seen in the mempool.
             </CardDescription>
           </CardHeader>
-          {unspentAmount > 0 &&
+          {unspentAmount > 0 && (
             <CardContent>{unspentAmount} sats deposited</CardContent>
-          }
+          )}
         </Card>
       </div>
-    </div >
+    </div>
   );
 }
 
@@ -525,9 +527,9 @@ function PayLightningChannelOrder({ order }: { order: NewChannelOrder }) {
   const newChannel =
     channels && prevChannels
       ? channels.find(
-        (newChannel) =>
-          !prevChannels.some((current) => current.id === newChannel.id)
-      )
+          (newChannel) =>
+            !prevChannels.some((current) => current.id === newChannel.id)
+        )
       : undefined;
 
   React.useEffect(() => {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/breez/breez-sdk-go v0.3.4
 	github.com/davrux/echo-logrus/v4 v4.0.3
 	github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8
-	github.com/getAlby/ldk-node-go v0.0.0-20240523143242-34e7c86a497e
+	github.com/getAlby/ldk-node-go v0.0.0-20240523190758-1c03aaaa6a2d
 	github.com/go-gormigrate/gormigrate/v2 v2.1.1
 	github.com/gorilla/sessions v1.2.2
 	github.com/labstack/echo-contrib v0.14.1

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/breez/breez-sdk-go v0.3.4
 	github.com/davrux/echo-logrus/v4 v4.0.3
 	github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8
-	github.com/getAlby/ldk-node-go v0.0.0-20240521192127-e0ba2ce83fb3
+	github.com/getAlby/ldk-node-go v0.0.0-20240523143242-34e7c86a497e
 	github.com/go-gormigrate/gormigrate/v2 v2.1.1
 	github.com/gorilla/sessions v1.2.2
 	github.com/labstack/echo-contrib v0.14.1

--- a/go.sum
+++ b/go.sum
@@ -234,10 +234,8 @@ github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8 h1:mJsdhUb8hmSSSLR2GQFw9BGtnJP7xmKB/XQxDt3DvAo=
 github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8/go.mod h1:ViyJvjlvv0GCesTJ7mb3fBo4G+/qsujDAFN90xZ7a9U=
-github.com/getAlby/ldk-node-go v0.0.0-20240521192127-e0ba2ce83fb3 h1:VSmfzMbNemFCt4wI3PnqRAY+bZZgOVjRJvGj1OtAKMo=
-github.com/getAlby/ldk-node-go v0.0.0-20240521192127-e0ba2ce83fb3/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
-github.com/getAlby/ldk-node-go v0.0.0-20240523143242-34e7c86a497e h1:nMMGWdtynmNC2Uiw5kpNK6Gv1PkB4rpztABVksAT6hA=
-github.com/getAlby/ldk-node-go v0.0.0-20240523143242-34e7c86a497e/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
+github.com/getAlby/ldk-node-go v0.0.0-20240523190758-1c03aaaa6a2d h1:6Xa8aZGpbdYGAz44O/vup9VW91dQGxT8OHyiygnjIog=
+github.com/getAlby/ldk-node-go v0.0.0-20240523190758-1c03aaaa6a2d/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/go.sum
+++ b/go.sum
@@ -236,6 +236,8 @@ github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8 h1:mJsdhUb8hmSSS
 github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8/go.mod h1:ViyJvjlvv0GCesTJ7mb3fBo4G+/qsujDAFN90xZ7a9U=
 github.com/getAlby/ldk-node-go v0.0.0-20240521192127-e0ba2ce83fb3 h1:VSmfzMbNemFCt4wI3PnqRAY+bZZgOVjRJvGj1OtAKMo=
 github.com/getAlby/ldk-node-go v0.0.0-20240521192127-e0ba2ce83fb3/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
+github.com/getAlby/ldk-node-go v0.0.0-20240523143242-34e7c86a497e h1:nMMGWdtynmNC2Uiw5kpNK6Gv1PkB4rpztABVksAT6hA=
+github.com/getAlby/ldk-node-go v0.0.0-20240523143242-34e7c86a497e/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/http_service.go
+++ b/http_service.go
@@ -95,6 +95,7 @@ func (httpSvc *HttpService) RegisterSharedRoutes(e *echo.Echo) {
 	e.POST("/api/wallet/new-address", httpSvc.newOnchainAddressHandler, authMiddleware)
 	e.POST("/api/wallet/redeem-onchain-funds", httpSvc.redeemOnchainFundsHandler, authMiddleware)
 	e.POST("/api/wallet/sign-message", httpSvc.signMessageHandler, authMiddleware)
+	e.POST("/api/request-wallet-sync", httpSvc.requestWalletSyncHandler, authMiddleware)
 	e.GET("/api/balances", httpSvc.balancesHandler, authMiddleware)
 	e.POST("/api/reset-router", httpSvc.resetRouterHandler, authMiddleware)
 	e.POST("/api/stop", httpSvc.stopHandler, authMiddleware)
@@ -380,6 +381,12 @@ func (httpSvc *HttpService) balancesHandler(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, balances)
+}
+
+func (httpSvc *HttpService) requestWalletSyncHandler(c echo.Context) error {
+	httpSvc.api.RequestWalletSync()
+
+	return c.NoContent(http.StatusNoContent)
 }
 
 func (httpSvc *HttpService) mempoolApiHandler(c echo.Context) error {

--- a/http_service.go
+++ b/http_service.go
@@ -95,7 +95,7 @@ func (httpSvc *HttpService) RegisterSharedRoutes(e *echo.Echo) {
 	e.POST("/api/wallet/new-address", httpSvc.newOnchainAddressHandler, authMiddleware)
 	e.POST("/api/wallet/redeem-onchain-funds", httpSvc.redeemOnchainFundsHandler, authMiddleware)
 	e.POST("/api/wallet/sign-message", httpSvc.signMessageHandler, authMiddleware)
-	e.POST("/api/request-wallet-sync", httpSvc.requestWalletSyncHandler, authMiddleware)
+	e.POST("/api/wallet/sync", httpSvc.walletSyncHandler, authMiddleware)
 	e.GET("/api/balances", httpSvc.balancesHandler, authMiddleware)
 	e.POST("/api/reset-router", httpSvc.resetRouterHandler, authMiddleware)
 	e.POST("/api/stop", httpSvc.stopHandler, authMiddleware)
@@ -383,8 +383,8 @@ func (httpSvc *HttpService) balancesHandler(c echo.Context) error {
 	return c.JSON(http.StatusOK, balances)
 }
 
-func (httpSvc *HttpService) requestWalletSyncHandler(c echo.Context) error {
-	httpSvc.api.RequestWalletSync()
+func (httpSvc *HttpService) walletSyncHandler(c echo.Context) error {
+	httpSvc.api.SyncWallet()
 
 	return c.NoContent(http.StatusNoContent)
 }

--- a/service.go
+++ b/service.go
@@ -52,6 +52,7 @@ type Service struct {
 	wg                     *sync.WaitGroup
 	nip47NotificationQueue nip47.Nip47NotificationQueue
 	appCancelFn            context.CancelFunc
+	lastWalletSyncRequest  time.Time
 }
 
 // TODO: move to service.go

--- a/wails_handlers.go
+++ b/wails_handlers.go
@@ -228,6 +228,9 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 		}
 		res := WailsRequestRouterResponse{Body: nil, Error: ""}
 		return res
+	case "/api/request-wallet-sync":
+		app.api.RequestWalletSync()
+		return WailsRequestRouterResponse{Body: nil, Error: ""}
 	case "/api/stop":
 		err := app.api.Stop()
 		if err != nil {

--- a/wails_handlers.go
+++ b/wails_handlers.go
@@ -228,9 +228,6 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 		}
 		res := WailsRequestRouterResponse{Body: nil, Error: ""}
 		return res
-	case "/api/request-wallet-sync":
-		app.api.RequestWalletSync()
-		return WailsRequestRouterResponse{Body: nil, Error: ""}
 	case "/api/stop":
 		err := app.api.Stop()
 		if err != nil {
@@ -278,7 +275,9 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 		}
 		res := WailsRequestRouterResponse{Body: *balancesResponse, Error: ""}
 		return res
-
+	case "/api/wallet/sync":
+		app.api.SyncWallet()
+		return WailsRequestRouterResponse{Body: nil, Error: ""}
 	case "/api/wallet/new-address":
 		newAddressResponse, err := app.api.GetNewOnchainAddress(ctx)
 		if err != nil {


### PR DESCRIPTION
In this change the NWC app will handle syncing the LDK wallet itself (rather than it originally happening in the background).

The LDK wallet always syncs immediately at startup (and the polling hack was removed!). If the initial sync fails, then the lnclient will not be started.

There's two sync times:
- Default: once per hour
- Frequent: once per minute (only when opening a new channel or on the channels/liquidity page)

On shutdown, I also ensure the current sync is completed before calling the actual LDK node shutdown method.

TODOs:
- [x] review method of requesting more frequent wallet syncs
- [x] merge https://github.com/getAlby/ldk-node/pull/24 and https://github.com/getAlby/ldk-node/pull/23
- [x] update ldk-node dependency for all environments