### PR TITLE
chore: add migration to remove content

### DIFF
--- a/db/models.go
+++ b/db/models.go
@@ -33,23 +33,21 @@ type AppPermission struct {
 }
 
 type RequestEvent struct {
-	ID        uint
-	AppId     *uint
-	App       App
-	NostrId   string `validate:"required"`
-	Content   string
+	ID          uint
+	AppId       *uint
+	App         App
+	NostrId     string `validate:"required"`
 	ContentData string
 	Method      string
-	State     string
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	State       string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
 }
 
 type ResponseEvent struct {
 	ID        uint
 	NostrId   string `validate:"required"`
 	RequestId uint   `validate:"required"`
-	Content   string
 	State     string
 	RepliedAt time.Time
 	CreatedAt time.Time

--- a/migrations/202406061259_delete_content.go
+++ b/migrations/202406061259_delete_content.go
@@ -22,14 +22,6 @@ var _202406061259_delete_content = &gormigrate.Migration{
 		return nil
 	},
 	Rollback: func(tx *gorm.DB) error {
-		if err := tx.Exec("ALTER TABLE response_events ADD COLUMN content TEXT").Error; err != nil {
-			return err
-		}
-
-		if err := tx.Exec("ALTER TABLE request_events ADD COLUMN content TEXT").Error; err != nil {
-			return err
-		}
-
 		return nil
 	},
 }

--- a/migrations/202406061259_delete_content.go
+++ b/migrations/202406061259_delete_content.go
@@ -1,0 +1,35 @@
+package migrations
+
+import (
+	_ "embed"
+
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+// Delete the content column from both request and response events table
+var _202406061259_delete_content = &gormigrate.Migration{
+	ID: "202406061259_remove_content_columns",
+	Migrate: func(tx *gorm.DB) error {
+		if err := tx.Exec("ALTER TABLE response_events DROP COLUMN content").Error; err != nil {
+			return err
+		}
+
+		if err := tx.Exec("ALTER TABLE request_events DROP COLUMN content").Error; err != nil {
+			return err
+		}
+
+		return nil
+	},
+	Rollback: func(tx *gorm.DB) error {
+		if err := tx.Exec("ALTER TABLE response_events ADD COLUMN content TEXT").Error; err != nil {
+			return err
+		}
+
+		if err := tx.Exec("ALTER TABLE request_events ADD COLUMN content TEXT").Error; err != nil {
+			return err
+		}
+
+		return nil
+	},
+}

--- a/migrations/migrate.go
+++ b/migrations/migrate.go
@@ -14,6 +14,7 @@ func Migrate(db *gorm.DB, appConfig *config.AppConfig, logger *logrus.Logger) er
 		_202403171120_delete_ldk_payments(appConfig, logger),
 		_202404021909_nullable_expires_at,
 		_202405302121_store_decrypted_request,
+		_202406061259_delete_content,
 	})
 
 	return m.Migrate()

--- a/service.go
+++ b/service.go
@@ -334,7 +334,7 @@ func (svc *Service) PublishEvent(ctx context.Context, sub *nostr.Subscription, r
 	if app != nil {
 		appId = &app.ID
 	}
-	responseEvent := db.ResponseEvent{NostrId: resp.ID, RequestId: requestEvent.ID, Content: resp.Content, State: "received"}
+	responseEvent := db.ResponseEvent{NostrId: resp.ID, RequestId: requestEvent.ID, State: "received"}
 	err := svc.db.Create(&responseEvent).Error
 	if err != nil {
 		svc.logger.WithFields(logrus.Fields{
@@ -399,7 +399,7 @@ func (svc *Service) HandleEvent(ctx context.Context, sub *nostr.Subscription, ev
 	}
 
 	// store request event
-	requestEvent := db.RequestEvent{AppId: nil, NostrId: event.ID, Content: event.Content, State: db.REQUEST_EVENT_STATE_HANDLER_EXECUTING}
+	requestEvent := db.RequestEvent{AppId: nil, NostrId: event.ID, State: db.REQUEST_EVENT_STATE_HANDLER_EXECUTING}
 	err = svc.db.Create(&requestEvent).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrDuplicatedKey) {

--- a/service_test.go
+++ b/service_test.go
@@ -433,12 +433,11 @@ func TestHandleMultiPayInvoiceEvent(t *testing.T) {
 		PubKey:  app.NostrPubkey,
 		Content: payload,
 	}
-	requestEvent := &db.RequestEvent{
-		Content: reqEvent.Content,
-	}
 
 	reqEvent.ID = "multi_pay_invoice_without_permission"
-	requestEvent.NostrId = reqEvent.ID
+	requestEvent := &db.RequestEvent{
+		NostrId: reqEvent.ID,
+	}
 
 	responses := []*nip47.Response{}
 	dTags := []nostr.Tags{}
@@ -557,12 +556,11 @@ func TestHandleMultiPayKeysendEvent(t *testing.T) {
 		PubKey:  app.NostrPubkey,
 		Content: payload,
 	}
-	requestEvent := &db.RequestEvent{
-		Content: reqEvent.Content,
-	}
 
 	reqEvent.ID = "multi_pay_keysend_without_permission"
-	requestEvent.NostrId = reqEvent.ID
+	requestEvent := &db.RequestEvent{
+		NostrId: reqEvent.ID,
+	}
 
 	responses := []*nip47.Response{}
 	dTags := []nostr.Tags{}
@@ -657,12 +655,11 @@ func TestHandleGetBalanceEvent(t *testing.T) {
 		PubKey:  app.NostrPubkey,
 		Content: payload,
 	}
-	requestEvent := &db.RequestEvent{
-		Content: reqEvent.Content,
-	}
 
 	reqEvent.ID = "test_get_balance_without_permission"
-	requestEvent.NostrId = reqEvent.ID
+	requestEvent := &db.RequestEvent{
+		NostrId: reqEvent.ID,
+	}
 
 	responses := []*nip47.Response{}
 
@@ -740,12 +737,11 @@ func TestHandlePayInvoiceEvent(t *testing.T) {
 		PubKey:  app.NostrPubkey,
 		Content: payload,
 	}
-	requestEvent := &db.RequestEvent{
-		Content: reqEvent.Content,
-	}
 
 	reqEvent.ID = "pay_invoice_without_permission"
-	requestEvent.NostrId = reqEvent.ID
+	requestEvent := &db.RequestEvent{
+		NostrId: reqEvent.ID,
+	}
 
 	responses := []*nip47.Response{}
 
@@ -874,12 +870,11 @@ func TestHandlePayKeysendEvent(t *testing.T) {
 		PubKey:  app.NostrPubkey,
 		Content: payload,
 	}
-	requestEvent := &db.RequestEvent{
-		Content: reqEvent.Content,
-	}
 
 	reqEvent.ID = "pay_keysend_without_permission"
-	requestEvent.NostrId = reqEvent.ID
+	requestEvent := &db.RequestEvent{
+		NostrId: reqEvent.ID,
+	}
 
 	responses := []*nip47.Response{}
 
@@ -958,12 +953,11 @@ func TestHandleLookupInvoiceEvent(t *testing.T) {
 		PubKey:  app.NostrPubkey,
 		Content: payload,
 	}
-	requestEvent := &db.RequestEvent{
-		Content: reqEvent.Content,
-	}
 
 	reqEvent.ID = "test_lookup_invoice_without_permission"
-	requestEvent.NostrId = reqEvent.ID
+	requestEvent := &db.RequestEvent{
+		NostrId: reqEvent.ID,
+	}
 
 	responses := []*nip47.Response{}
 
@@ -1025,12 +1019,11 @@ func TestHandleMakeInvoiceEvent(t *testing.T) {
 		PubKey:  app.NostrPubkey,
 		Content: payload,
 	}
-	requestEvent := &db.RequestEvent{
-		Content: reqEvent.Content,
-	}
 
 	reqEvent.ID = "test_make_invoice_without_permission"
-	requestEvent.NostrId = reqEvent.ID
+	requestEvent := &db.RequestEvent{
+		NostrId: reqEvent.ID,
+	}
 
 	responses := []*nip47.Response{}
 
@@ -1083,12 +1076,11 @@ func TestHandleListTransactionsEvent(t *testing.T) {
 		PubKey:  app.NostrPubkey,
 		Content: payload,
 	}
-	requestEvent := &db.RequestEvent{
-		Content: reqEvent.Content,
-	}
 
 	reqEvent.ID = "test_list_transactions_without_permission"
-	requestEvent.NostrId = reqEvent.ID
+	requestEvent := &db.RequestEvent{
+		NostrId: reqEvent.ID,
+	}
 
 	responses := []*nip47.Response{}
 
@@ -1151,12 +1143,11 @@ func TestHandleGetInfoEvent(t *testing.T) {
 		PubKey:  app.NostrPubkey,
 		Content: payload,
 	}
-	requestEvent := &db.RequestEvent{
-		Content: reqEvent.Content,
-	}
 
 	reqEvent.ID = "test_get_info_without_permission"
-	requestEvent.NostrId = reqEvent.ID
+	requestEvent := &db.RequestEvent{
+		NostrId: reqEvent.ID,
+	}
 
 	responses := []*nip47.Response{}
 


### PR DESCRIPTION
Fixes #328 

Removes content from `request_events` and `response_events`

⚠️ This does not add `contentData` to `response_events` (like it is done in `request_events` table in #359) so now we don't store anything content-related from the response