### PR TITLE
chore: add vacuuming after migration

### DIFF
--- a/migrations/202406061259_delete_content.go
+++ b/migrations/202406061259_delete_content.go
@@ -19,6 +19,10 @@ var _202406061259_delete_content = &gormigrate.Migration{
 			return err
 		}
 
+		if err := tx.Exec("VACUUM").Error; err != nil {
+			return err
+		}
+
 		return nil
 	},
 	Rollback: func(tx *gorm.DB) error {


### PR DESCRIPTION
Adds vacuum post the migration (follow up to #392 merged just now)