### PR TITLE
fix: support preset node from env in new node selection UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -53,6 +53,7 @@ import { GreenlightForm } from "src/screens/setup/node/GreenlightForm";
 import { LDKForm } from "src/screens/setup/node/LDKForm";
 import { LNDForm } from "src/screens/setup/node/LNDForm";
 import { PhoenixdForm } from "src/screens/setup/node/PhoenixdForm";
+import { PresetNodeForm } from "src/screens/setup/node/PresetNodeForm";
 
 function App() {
   usePosthog();
@@ -132,6 +133,7 @@ function App() {
                   <Route path="breez" element={<BreezForm />} />
                   <Route path="greenlight" element={<GreenlightForm />} />
                   <Route path="ldk" element={<LDKForm />} />
+                  <Route path="preset" element={<PresetNodeForm />} />
                   <Route path="lnd" element={<LNDForm />} />
                   <Route path="cashu" element={<CashuForm />} />
                   <Route path="phoenix" element={<PhoenixdForm />} />

--- a/frontend/src/screens/Welcome.tsx
+++ b/frontend/src/screens/Welcome.tsx
@@ -37,16 +37,25 @@ export function Welcome() {
           </p>
         </div>
         <div className="grid gap-2">
-          <Link to="/setup/password?node=ldk" className="w-full">
-            <Button className="w-full">Get Started</Button>
+          <Link
+            to={
+              info?.backendType
+                ? "/setup/password?node=preset" // node already setup through env variables
+                : "/setup/password?node=ldk"
+            }
+            className="w-full"
+          >
+            <Button className="w-full">
+              Get Started
+              {info?.backendType && ` (${info?.backendType})`}
+            </Button>
           </Link>
-          {!info?.backendType && (
-            <Link to="/setup/advanced" className="w-full">
-              <Button variant="secondary" className="w-full">
-                Advanced Setup
-              </Button>
-            </Link>
-          )}
+
+          <Link to="/setup/advanced" className="w-full">
+            <Button variant="secondary" className="w-full">
+              Advanced Setup
+            </Button>
+          </Link>
         </div>
         <div className="text-sm text-muted-foreground">
           By continuing, you agree to our <br />

--- a/frontend/src/screens/setup/node/PresetNodeForm.tsx
+++ b/frontend/src/screens/setup/node/PresetNodeForm.tsx
@@ -1,0 +1,31 @@
+import { wordlist } from "@scure/bip39/wordlists/english";
+import { useEffect } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import useSetupStore from "src/state/SetupStore";
+
+import * as bip39 from "@scure/bip39";
+import Loading from "src/components/Loading";
+import { useInfo } from "src/hooks/useInfo";
+import { backendTypeHasMnemonic } from "src/lib/utils";
+
+export function PresetNodeForm() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const { data: info } = useInfo();
+
+  // No configuration needed, automatically proceed with the next step
+  useEffect(() => {
+    if (!info) {
+      return;
+    }
+    if (backendTypeHasMnemonic(info.backendType)) {
+      useSetupStore.getState().updateNodeInfo({
+        mnemonic: bip39.generateMnemonic(wordlist, 128),
+      });
+    }
+
+    navigate("/setup/finish");
+  }, [info, navigate, searchParams]);
+
+  return <Loading />;
+}


### PR DESCRIPTION
This PR re-allows you to setup your node via env variables, and have one click to get started with a different node backend than LDK.