### PR TITLE
Embed webview if not available

### DIFF
--- a/.github/workflows/wails2.yaml
+++ b/.github/workflows/wails2.yaml
@@ -84,17 +84,17 @@ jobs:
 
       - name: Build App
         if: runner.os == 'macOS'
-        run: wails build --platform darwin/universal -webview2 download -o ${{ matrix.build.name }} -tags "wails"
+        run: wails build --platform darwin/universal -webview2 embed -o ${{ matrix.build.name }} -tags "wails"
         shell: bash
 
       - name: Build App
         if: runner.os == 'Linux'
-        run: wails build --platform linux/amd64 -webview2 download -o ${{ matrix.build.name }} -tags "wails"
+        run: wails build --platform linux/amd64 -webview2 embed -o ${{ matrix.build.name }} -tags "wails"
         shell: bash
 
       - name: Build Windows App
         if: runner.os == 'Windows'
-        run: wails build --platform windows/amd64 -webview2 download -o ${{ matrix.build.name }}.exe -tags "wails"
+        run: wails build --platform windows/amd64 -webview2 embed -o ${{ matrix.build.name }}.exe -tags "wails"
         shell: bash
 
       - name: Copy DLLs to the output directory


### PR DESCRIPTION
This embeds the webview dependency which will be used if the webview is not available. 
Otherwise the user would get prompted to download it and I thought this is easier. 

https://wails.io/docs/guides/windows/

