### PR TITLE
Fix: LSPS1 public 6 confirmations, LND simultaneous support 0-conf and non-0-conf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/davrux/echo-logrus/v4 v4.0.3
 	github.com/elnosh/gonuts v0.1.1-0.20240602162005-49da741613e4
 	github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8
-	github.com/getAlby/ldk-node-go v0.0.0-20240603135137-7fe56c466ffd
+	github.com/getAlby/ldk-node-go v0.0.0-20240613043419-a3ae86f6a26d
 	github.com/go-gormigrate/gormigrate/v2 v2.1.1
 	github.com/gorilla/sessions v1.2.2
 	github.com/labstack/echo-contrib v0.14.1
@@ -227,7 +227,7 @@ require (
 
 require (
 	github.com/btcsuite/btcd/btcec/v2 v2.3.3 // indirect
-	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0 // indirect
+	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
 	github.com/decred/dcrd/crypto/blake256 v1.0.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
 	github.com/glebarez/sqlite v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwV
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8 h1:mJsdhUb8hmSSSLR2GQFw9BGtnJP7xmKB/XQxDt3DvAo=
 github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8/go.mod h1:ViyJvjlvv0GCesTJ7mb3fBo4G+/qsujDAFN90xZ7a9U=
-github.com/getAlby/ldk-node-go v0.0.0-20240603135137-7fe56c466ffd h1:pYqFkK0TuKG8WFjHb80qod5zc0jvHSwT55rb5/W3u4s=
-github.com/getAlby/ldk-node-go v0.0.0-20240603135137-7fe56c466ffd/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
+github.com/getAlby/ldk-node-go v0.0.0-20240613043419-a3ae86f6a26d h1:pj+/wYZ3TFzJt2fGQaf7naAqWluR0HlzLGNFAiwoe3g=
+github.com/getAlby/ldk-node-go v0.0.0-20240613043419-a3ae86f6a26d/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/lsp/lsp_service.go
+++ b/lsp/lsp_service.go
@@ -543,11 +543,19 @@ func (ls *lspService) requestLSPS1Invoice(ctx context.Context, selectedLsp *LSP,
 		return "", 0, err
 	}
 
+	var requiredChannelConfirmations uint64 = 0
+
+	if public {
+		// as per BOLT-7 6 confirmations are required for the channel to be gossiped
+		// https://github.com/lightning/bolts/blob/master/07-routing-gossip.md#requirements
+		requiredChannelConfirmations = 6
+	}
+
 	newLSPS1ChannelRequest := NewLSPS1ChannelRequest{
 		PublicKey:                    pubkey,
 		LSPBalanceSat:                strconv.FormatUint(amount, 10),
 		ClientBalanceSat:             "0",
-		RequiredChannelConfirmations: 0,
+		RequiredChannelConfirmations: requiredChannelConfirmations,
 		FundingConfirmsWithinBlocks:  6,
 		ChannelExpiryBlocks:          13000, // TODO: this should be customizable
 		Token:                        "",


### PR DESCRIPTION
For LSPS1 public channels, as per BOLT-7 6 confirmations are required for the channel to be gossiped. So to make the UX flow nice (especially for podcasters) it makes sense to only mark the channel as active after 6 confirmations.

Supposedly LDK should add public route hints before that, but it won't work for podcasting and doesn't seem to work for normal invoices either.

This also enables simultaneous 0-conf and non-0-conf support for a couple of whitelisted LSP nodes (Olympus and Megalith). See https://github.com/getAlby/ldk-node/commit/fe5cc20eb1dd3dcb7dc576b01e5e3081839d7b63 (as a workaround until the LND bug is fixed - this is only needed for LSPs which we want both 0-conf and non-0-conf)