### PR TITLE
feat: add ldk custom tlvs to metadata custom records

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/davrux/echo-logrus/v4 v4.0.3
 	github.com/elnosh/gonuts v0.1.1-0.20240602162005-49da741613e4
 	github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8
-	github.com/getAlby/ldk-node-go v0.0.0-20240613043419-a3ae86f6a26d
+	github.com/getAlby/ldk-node-go v0.0.0-20240614062656-d4de573a1996
 	github.com/go-gormigrate/gormigrate/v2 v2.1.1
 	github.com/gorilla/sessions v1.2.2
 	github.com/labstack/echo-contrib v0.14.1

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwV
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8 h1:mJsdhUb8hmSSSLR2GQFw9BGtnJP7xmKB/XQxDt3DvAo=
 github.com/getAlby/glalby-go v0.0.0-20240416174357-e6e2faa2fbd8/go.mod h1:ViyJvjlvv0GCesTJ7mb3fBo4G+/qsujDAFN90xZ7a9U=
-github.com/getAlby/ldk-node-go v0.0.0-20240613043419-a3ae86f6a26d h1:pj+/wYZ3TFzJt2fGQaf7naAqWluR0HlzLGNFAiwoe3g=
-github.com/getAlby/ldk-node-go v0.0.0-20240613043419-a3ae86f6a26d/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
+github.com/getAlby/ldk-node-go v0.0.0-20240614062656-d4de573a1996 h1:UULF8HX3z0kxgppzDX67oG/7t1Es+tpZogqtsYsguX0=
+github.com/getAlby/ldk-node-go v0.0.0-20240614062656-d4de573a1996/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=


### PR DESCRIPTION
This enables NWC apps that display transactions to show podcasting 2.0 details

See https://github.com/getAlby/lightning-browser-extension/pull/3172 for how it is consumed.

Note: this is inconsistent with how the TLVs are passed in https://github.com/nostr-protocol/nips/blob/master/47.md#pay_keysend

In retrospect I think this should actually be changed to be `metadata.tlv_records` and have the same format as `pay_keysend`