### PR TITLE
feat: update channel

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -390,6 +390,16 @@ func (api *api) CloseChannel(ctx context.Context, peerId, channelId string, forc
 	})
 }
 
+func (api *api) UpdateChannel(ctx context.Context, updateChannelRequest *UpdateChannelRequest) error {
+	if api.svc.GetLNClient() == nil {
+		return errors.New("LNClient not started")
+	}
+	logger.Logger.WithFields(logrus.Fields{
+		"request": updateChannelRequest,
+	}).Info("updating channel")
+	return api.svc.GetLNClient().UpdateChannel(ctx, updateChannelRequest)
+}
+
 func (api *api) GetNewOnchainAddress(ctx context.Context) (string, error) {
 	if api.svc.GetLNClient() == nil {
 		return "", errors.New("LNClient not started")

--- a/api/models.go
+++ b/api/models.go
@@ -28,6 +28,7 @@ type API interface {
 	DisconnectPeer(ctx context.Context, peerId string) error
 	OpenChannel(ctx context.Context, openChannelRequest *OpenChannelRequest) (*OpenChannelResponse, error)
 	CloseChannel(ctx context.Context, peerId, channelId string, force bool) (*CloseChannelResponse, error)
+	UpdateChannel(ctx context.Context, updateChannelRequest *UpdateChannelRequest) error
 	GetNewOnchainAddress(ctx context.Context) (string, error)
 	GetUnusedOnchainAddress(ctx context.Context) (string, error)
 	SignMessage(ctx context.Context, message string) (*SignMessageResponse, error)
@@ -163,6 +164,7 @@ type ConnectPeerRequest = lnclient.ConnectPeerRequest
 type OpenChannelRequest = lnclient.OpenChannelRequest
 type OpenChannelResponse = lnclient.OpenChannelResponse
 type CloseChannelResponse = lnclient.CloseChannelResponse
+type UpdateChannelRequest = lnclient.UpdateChannelRequest
 
 type RedeemOnchainFundsRequest struct {
 	ToAddress string `json:"toAddress"`

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -172,6 +172,11 @@ export type Channel = {
   public: boolean;
   confirmations?: number;
   confirmationsRequired?: number;
+  forwardingFeeBaseMsat: number;
+};
+
+export type UpdateChannelRequest = {
+  forwardingFeeBaseMsat: number;
 };
 
 export type Peer = {

--- a/lnclient/breez/breez.go
+++ b/lnclient/breez/breez.go
@@ -462,6 +462,10 @@ func (bs *BreezService) GetNetworkGraph(nodeIds []string) (lnclient.NetworkGraph
 
 func (bs *BreezService) UpdateLastWalletSyncRequest() {}
 
+func (bs *BreezService) UpdateChannel(ctx context.Context, updateChannelRequest *lnclient.UpdateChannelRequest) error {
+	return nil
+}
+
 func (bs *BreezService) DisconnectPeer(ctx context.Context, peerId string) error {
 	return nil
 }

--- a/lnclient/cashu/cashu.go
+++ b/lnclient/cashu/cashu.go
@@ -247,7 +247,12 @@ func (cs *CashuService) GetNodeStatus(ctx context.Context) (nodeStatus *lnclient
 func (cs *CashuService) SendPaymentProbes(ctx context.Context, invoice string) error {
 	return nil
 }
+
 func (cs *CashuService) SendSpontaneousPaymentProbes(ctx context.Context, amountMsat uint64, nodeId string) error {
+	return nil
+}
+
+func (cs *CashuService) UpdateChannel(ctx context.Context, updateChannelRequest *lnclient.UpdateChannelRequest) error {
 	return nil
 }
 

--- a/lnclient/greenlight/greenlight.go
+++ b/lnclient/greenlight/greenlight.go
@@ -664,6 +664,10 @@ func (gs *GreenlightService) GetNetworkGraph(nodeIds []string) (lnclient.Network
 
 func (gs *GreenlightService) UpdateLastWalletSyncRequest() {}
 
+func (gs *GreenlightService) UpdateChannel(ctx context.Context, updateChannelRequest *lnclient.UpdateChannelRequest) error {
+	return nil
+}
+
 func (gs *GreenlightService) DisconnectPeer(ctx context.Context, peerId string) error {
 	return nil
 }

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -862,8 +862,8 @@ func (ls *LDKService) OpenChannel(ctx context.Context, openChannelRequest *lncli
 
 	channelConfig := ldk_node.NewChannelConfig()
 
-	// TODO: consider setting a super-high forwarding fee by default to disable unwanted routing
-	// channelConfig.SetForwardingFeeBaseMsat(100_000_000)
+	// set a super-high forwarding fee of 100K sats by default to disable unwanted routing
+	channelConfig.SetForwardingFeeBaseMsat(100_000_000)
 
 	logger.Logger.WithField("peer_id", foundPeer.NodeId).Info("Opening channel")
 	userChannelId, err := ls.node.ConnectOpenChannel(foundPeer.NodeId, foundPeer.Address, uint64(openChannelRequest.Amount), nil, &channelConfig, openChannelRequest.Public)

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -781,8 +781,18 @@ func (ls *LDKService) ListChannels(ctx context.Context) ([]lnclient.Channel, err
 			fundingTxId = ldkChannel.FundingTxo.Txid
 		}
 
+		internalChannel := map[string]interface{}{}
+		internalChannel["channel"] = ldkChannel
+		internalChannel["config"] = map[string]interface{}{
+			"AcceptUnderpayingHtlcs":              ldkChannel.Config.AcceptUnderpayingHtlcs(),
+			"CltvExpiryDelta":                     ldkChannel.Config.CltvExpiryDelta(),
+			"ForceCloseAvoidanceMaxFeeSatoshis":   ldkChannel.Config.ForceCloseAvoidanceMaxFeeSatoshis(),
+			"ForwardingFeeBaseMsat":               ldkChannel.Config.ForwardingFeeBaseMsat(),
+			"ForwardingFeeProportionalMillionths": ldkChannel.Config.ForwardingFeeProportionalMillionths(),
+		}
+
 		channels = append(channels, lnclient.Channel{
-			InternalChannel:       ldkChannel,
+			InternalChannel:       internalChannel,
 			LocalBalance:          int64(ldkChannel.OutboundCapacityMsat),
 			RemoteBalance:         int64(ldkChannel.InboundCapacityMsat),
 			RemotePubkey:          ldkChannel.CounterpartyNodeId,
@@ -792,6 +802,7 @@ func (ls *LDKService) ListChannels(ctx context.Context) ([]lnclient.Channel, err
 			FundingTxId:           fundingTxId,
 			Confirmations:         ldkChannel.Confirmations,
 			ConfirmationsRequired: ldkChannel.ConfirmationsRequired,
+			ForwardingFeeBaseMsat: ldkChannel.Config.ForwardingFeeBaseMsat(),
 		})
 	}
 
@@ -849,8 +860,13 @@ func (ls *LDKService) OpenChannel(ctx context.Context, openChannelRequest *lncli
 	ldkEventSubscription := ls.ldkEventBroadcaster.Subscribe()
 	defer ls.ldkEventBroadcaster.CancelSubscription(ldkEventSubscription)
 
+	channelConfig := ldk_node.NewChannelConfig()
+
+	// TODO: consider setting a super-high forwarding fee by default to disable unwanted routing
+	// channelConfig.SetForwardingFeeBaseMsat(100_000_000)
+
 	logger.Logger.WithField("peer_id", foundPeer.NodeId).Info("Opening channel")
-	userChannelId, err := ls.node.ConnectOpenChannel(foundPeer.NodeId, foundPeer.Address, uint64(openChannelRequest.Amount), nil, nil, openChannelRequest.Public)
+	userChannelId, err := ls.node.ConnectOpenChannel(foundPeer.NodeId, foundPeer.Address, uint64(openChannelRequest.Amount), nil, &channelConfig, openChannelRequest.Public)
 	if err != nil {
 		logger.Logger.WithError(err).Error("OpenChannel failed")
 		return nil, err
@@ -888,6 +904,32 @@ func (ls *LDKService) OpenChannel(ctx context.Context, openChannelRequest *lncli
 	}
 
 	return nil, errors.New("open channel timeout")
+}
+
+func (ls *LDKService) UpdateChannel(ctx context.Context, updateChannelRequest *lnclient.UpdateChannelRequest) error {
+	channels := ls.node.ListChannels()
+
+	var foundChannel *ldk_node.ChannelDetails
+	for _, channel := range channels {
+		if channel.UserChannelId == updateChannelRequest.ChannelId && channel.CounterpartyNodeId == updateChannelRequest.NodeId {
+			foundChannel = &channel
+			break
+		}
+	}
+
+	if foundChannel == nil {
+		return errors.New("channel not found")
+	}
+
+	existingConfig := foundChannel.Config
+	existingConfig.SetForwardingFeeBaseMsat(updateChannelRequest.ForwardingFeeBaseMsat)
+
+	err := ls.node.UpdateChannelConfig(updateChannelRequest.ChannelId, updateChannelRequest.NodeId, existingConfig)
+	if err != nil {
+		logger.Logger.WithError(err).Error("UpdateChannelConfig failed")
+		return err
+	}
+	return nil
 }
 
 func (ls *LDKService) CloseChannel(ctx context.Context, closeChannelRequest *lnclient.CloseChannelRequest) (*lnclient.CloseChannelResponse, error) {

--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -727,6 +727,10 @@ func (svc *LNDService) GetNetworkGraph(nodeIds []string) (lnclient.NetworkGraphR
 
 func (svc *LNDService) UpdateLastWalletSyncRequest() {}
 
+func (svc *LNDService) UpdateChannel(ctx context.Context, updateChannelRequest *lnclient.UpdateChannelRequest) error {
+	return nil
+}
+
 func (svc *LNDService) DisconnectPeer(ctx context.Context, peerId string) error {
 	return nil
 }

--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -728,6 +728,48 @@ func (svc *LNDService) GetNetworkGraph(nodeIds []string) (lnclient.NetworkGraphR
 func (svc *LNDService) UpdateLastWalletSyncRequest() {}
 
 func (svc *LNDService) UpdateChannel(ctx context.Context, updateChannelRequest *lnclient.UpdateChannelRequest) error {
+	logger.Logger.WithFields(logrus.Fields{
+		"request": updateChannelRequest,
+	}).Info("Updating Channel")
+
+	chanId64, err := strconv.ParseUint(updateChannelRequest.ChannelId, 10, 64)
+	if err != nil {
+		return err
+	}
+
+	channelEdge, err := svc.client.GetChanInfo(ctx, &lnrpc.ChanInfoRequest{
+		ChanId: chanId64,
+	})
+	if err != nil {
+		return err
+	}
+
+	channelPoint, err := svc.parseChannelPoint(channelEdge.ChanPoint)
+	if err != nil {
+		return err
+	}
+
+	var nodePolicy *lnrpc.RoutingPolicy
+	if channelEdge.Node1Pub == svc.client.IdentityPubkey {
+		nodePolicy = channelEdge.Node1Policy
+	} else {
+		nodePolicy = channelEdge.Node2Policy
+	}
+
+	_, err = svc.client.UpdateChannel(ctx, &lnrpc.PolicyUpdateRequest{
+		Scope: &lnrpc.PolicyUpdateRequest_ChanPoint{
+			ChanPoint: channelPoint,
+		},
+		BaseFeeMsat:   int64(updateChannelRequest.ForwardingFeeBaseMsat),
+		FeeRatePpm:    uint32(nodePolicy.FeeRateMilliMsat),
+		TimeLockDelta: nodePolicy.TimeLockDelta,
+		MaxHtlcMsat:   nodePolicy.MaxHtlcMsat,
+	})
+
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -496,6 +496,8 @@ func (svc *LNDService) OpenChannel(ctx context.Context, openChannelRequest *lncl
 		NodePubkey:         nodePub,
 		Private:            !openChannelRequest.Public,
 		LocalFundingAmount: openChannelRequest.Amount,
+		// set a super-high forwarding fee of 100K sats by default to disable unwanted routing
+		BaseFee: 100_000_000,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to open channel with %s: %s", foundPeer.NodeId, err)

--- a/lnclient/lnd/wrapper/lnd.go
+++ b/lnclient/lnd/wrapper/lnd.go
@@ -176,3 +176,11 @@ func (wrapper *LNDWrapper) WalletBalance(ctx context.Context, req *lnrpc.WalletB
 func (wrapper *LNDWrapper) NewAddress(ctx context.Context, req *lnrpc.NewAddressRequest, options ...grpc.CallOption) (*lnrpc.NewAddressResponse, error) {
 	return wrapper.client.NewAddress(ctx, req, options...)
 }
+
+func (wrapper *LNDWrapper) GetChanInfo(ctx context.Context, req *lnrpc.ChanInfoRequest, options ...grpc.CallOption) (*lnrpc.ChannelEdge, error) {
+	return wrapper.client.GetChanInfo(ctx, req, options...)
+}
+
+func (wrapper *LNDWrapper) UpdateChannel(ctx context.Context, req *lnrpc.PolicyUpdateRequest, options ...grpc.CallOption) (*lnrpc.PolicyUpdateResponse, error) {
+	return wrapper.client.UpdateChannelPolicy(ctx, req, options...)
+}

--- a/lnclient/models.go
+++ b/lnclient/models.go
@@ -56,6 +56,7 @@ type LNClient interface {
 	ConnectPeer(ctx context.Context, connectPeerRequest *ConnectPeerRequest) error
 	OpenChannel(ctx context.Context, openChannelRequest *OpenChannelRequest) (*OpenChannelResponse, error)
 	CloseChannel(ctx context.Context, closeChannelRequest *CloseChannelRequest) (*CloseChannelResponse, error)
+	UpdateChannel(ctx context.Context, updateChannelRequest *UpdateChannelRequest) error
 	DisconnectPeer(ctx context.Context, peerId string) error
 	GetNewOnchainAddress(ctx context.Context) (string, error)
 	ResetRouter(key string) error
@@ -83,6 +84,7 @@ type Channel struct {
 	InternalChannel       interface{} `json:"internalChannel"`
 	Confirmations         *uint32     `json:"confirmations"`
 	ConfirmationsRequired *uint32     `json:"confirmationsRequired"`
+	ForwardingFeeBaseMsat uint32      `json:"forwardingFeeBaseMsat"`
 }
 
 type NodeStatus struct {
@@ -109,6 +111,12 @@ type CloseChannelRequest struct {
 	ChannelId string `json:"channelId"`
 	NodeId    string `json:"nodeId"`
 	Force     bool   `json:"force"`
+}
+
+type UpdateChannelRequest struct {
+	ChannelId             string `json:"channelId"`
+	NodeId                string `json:"nodeId"`
+	ForwardingFeeBaseMsat uint32 `json:"forwardingFeeBaseMsat"`
 }
 
 type CloseChannelResponse struct {

--- a/lnclient/phoenixd/phoenixd.go
+++ b/lnclient/phoenixd/phoenixd.go
@@ -479,6 +479,11 @@ func (svc *PhoenixService) GetNetworkGraph(nodeIds []string) (lnclient.NetworkGr
 }
 
 func (svc *PhoenixService) UpdateLastWalletSyncRequest() {}
+
 func (svc *PhoenixService) DisconnectPeer(ctx context.Context, peerId string) error {
+	return nil
+}
+
+func (svc *PhoenixService) UpdateChannel(ctx context.Context, updateChannelRequest *lnclient.UpdateChannelRequest) error {
 	return nil
 }

--- a/tests/mock_ln_client.go
+++ b/tests/mock_ln_client.go
@@ -150,7 +150,13 @@ func (mln *MockLn) GetNodeStatus(ctx context.Context) (nodeStatus *lnclient.Node
 func (mln *MockLn) GetNetworkGraph(nodeIds []string) (lnclient.NetworkGraphResponse, error) {
 	return nil, nil
 }
+
 func (mln *MockLn) UpdateLastWalletSyncRequest() {}
+
 func (mln *MockLn) DisconnectPeer(ctx context.Context, peerId string) error {
+	return nil
+}
+
+func (mln *MockLn) UpdateChannel(ctx context.Context, updateChannelRequest *lnclient.UpdateChannelRequest) error {
 	return nil
 }


### PR DESCRIPTION
Users can now update base forwarding fees on public channels. A high value can be set to prevent routing.

![image](https://github.com/getAlby/nostr-wallet-connect-next/assets/33993199/bae859f2-0003-4b06-8922-a9f69936ae09)

![image](https://github.com/getAlby/nostr-wallet-connect-next/assets/33993199/948e6d31-368e-4a4c-bf68-1b78937298b5)

