### PR TITLE
Chore: payment sent notification improvements

### DIFF
--- a/events/models.go
+++ b/events/models.go
@@ -23,8 +23,7 @@ type PaymentReceivedEventProperties struct {
 }
 
 type PaymentSentEventProperties struct {
-	PaymentHash string  `json:"payment_hash"`
-	Duration    *uint64 `json:"duration"`
+	PaymentHash string `json:"payment_hash"`
 }
 
 type ChannelBackupEvent struct {

--- a/events/models.go
+++ b/events/models.go
@@ -23,7 +23,8 @@ type PaymentReceivedEventProperties struct {
 }
 
 type PaymentSentEventProperties struct {
-	PaymentHash string `json:"payment_hash"`
+	PaymentHash string  `json:"payment_hash"`
+	Duration    *uint64 `json:"duration"`
 }
 
 type ChannelBackupEvent struct {

--- a/events/models.go
+++ b/events/models.go
@@ -20,15 +20,10 @@ type Event struct {
 
 type PaymentReceivedEventProperties struct {
 	PaymentHash string `json:"payment_hash"`
-	Amount      uint64 `json:"amount"`
-	NodeType    string `json:"node_type"`
 }
 
 type PaymentSentEventProperties struct {
-	PaymentId   string `json:"payment_id"`
 	PaymentHash string `json:"payment_hash"`
-	Amount      uint64 `json:"amount"`
-	NodeType    string `json:"node_type"`
 }
 
 type ChannelBackupEvent struct {

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -19,7 +19,7 @@ const EmptyState: React.FC<Props> = ({
   buttonLink,
 }) => {
   return (
-    <div className="flex flex-1 items-center justify-center rounded-lg border border-dashed shadow-sm">
+    <div className="flex flex-1 items-center justify-center rounded-lg border border-dashed shadow-sm py-8">
       <div className="flex flex-col items-center gap-1 text-center max-w-sm">
         <Icon className="w-10 h-10 text-muted-foreground" />
         <h3 className="mt-4 text-lg font-semibold">{message}</h3>

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -1224,27 +1224,10 @@ func (ls *LDKService) handleLdkEvent(event *ldk_node.Event) {
 			},
 		})
 	case ldk_node.EventPaymentSuccessful:
-		var duration *uint64 = nil
-		if eventType.PaymentId != nil {
-			payment := ls.node.Payment(*eventType.PaymentId)
-			if payment != nil {
-				bolt11PaymentKind, ok := payment.Kind.(ldk_node.PaymentKindBolt11)
-
-				if ok {
-					paymentRequest, err := decodepay.Decodepay(*bolt11PaymentKind.Bolt11Invoice)
-					if err == nil {
-						durationDiff := payment.LastUpdate - uint64(paymentRequest.CreatedAt)
-						duration = &durationDiff
-					}
-				}
-			}
-		}
-
 		ls.eventPublisher.Publish(&events.Event{
 			Event: "nwc_payment_sent",
 			Properties: &events.PaymentSentEventProperties{
 				PaymentHash: eventType.PaymentHash,
-				Duration:    duration,
 			},
 		})
 	}

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -1225,18 +1225,13 @@ func (ls *LDKService) handleLdkEvent(event *ldk_node.Event) {
 			Event: "nwc_payment_received",
 			Properties: &events.PaymentReceivedEventProperties{
 				PaymentHash: eventType.PaymentHash,
-				Amount:      eventType.AmountMsat / 1000,
-				NodeType:    config.LDKBackendType,
 			},
 		})
 	case ldk_node.EventPaymentSuccessful:
 		ls.eventPublisher.Publish(&events.Event{
 			Event: "nwc_payment_sent",
 			Properties: &events.PaymentSentEventProperties{
-				PaymentId:   *eventType.PaymentId,
 				PaymentHash: eventType.PaymentHash,
-				Amount:      *eventType.FeePaidMsat / 1000,
-				NodeType:    config.LDKBackendType,
 			},
 		})
 	}

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -370,10 +370,6 @@ func (ls *LDKService) resetRouterInternal() {
 		logger.Logger.WithFields(logrus.Fields{
 			"rowsAffected": rowsAffected,
 		}).Info("Reset router")
-
-		if err != nil {
-			logger.Logger.WithField("key", key).WithError(err).Error("ResetRouter failed")
-		}
 	}
 }
 
@@ -1228,10 +1224,27 @@ func (ls *LDKService) handleLdkEvent(event *ldk_node.Event) {
 			},
 		})
 	case ldk_node.EventPaymentSuccessful:
+		var duration *uint64 = nil
+		if eventType.PaymentId != nil {
+			payment := ls.node.Payment(*eventType.PaymentId)
+			if payment != nil {
+				bolt11PaymentKind, ok := payment.Kind.(ldk_node.PaymentKindBolt11)
+
+				if ok {
+					paymentRequest, err := decodepay.Decodepay(*bolt11PaymentKind.Bolt11Invoice)
+					if err == nil {
+						durationDiff := payment.LastUpdate - uint64(paymentRequest.CreatedAt)
+						duration = &durationDiff
+					}
+				}
+			}
+		}
+
 		ls.eventPublisher.Publish(&events.Event{
 			Event: "nwc_payment_sent",
 			Properties: &events.PaymentSentEventProperties{
 				PaymentHash: eventType.PaymentHash,
+				Duration:    duration,
 			},
 		})
 	}

--- a/nip47/controllers/get_info_controller_test.go
+++ b/nip47/controllers/get_info_controller_test.go
@@ -111,4 +111,66 @@ func TestHandleGetInfoEvent_WithPermission(t *testing.T) {
 	assert.Equal(t, tests.MockNodeInfo.BlockHeight, nodeInfo.BlockHeight)
 	assert.Equal(t, tests.MockNodeInfo.BlockHash, nodeInfo.BlockHash)
 	assert.Equal(t, []string{"get_info"}, nodeInfo.Methods)
+	assert.Equal(t, []string{}, nodeInfo.Notifications)
+}
+
+func TestHandleGetInfoEvent_WithNotifications(t *testing.T) {
+	ctx := context.TODO()
+	defer tests.RemoveTestService()
+	svc, err := tests.CreateTestService()
+	assert.NoError(t, err)
+
+	app, _, err := tests.CreateApp(svc)
+	assert.NoError(t, err)
+
+	nip47Request := &models.Request{}
+	err = json.Unmarshal([]byte(nip47GetInfoJson), nip47Request)
+	assert.NoError(t, err)
+
+	dbRequestEvent := &db.RequestEvent{}
+	err = svc.DB.Create(&dbRequestEvent).Error
+	assert.NoError(t, err)
+
+	appPermission := &db.AppPermission{
+		AppId:         app.ID,
+		RequestMethod: models.GET_INFO_METHOD,
+		ExpiresAt:     nil,
+	}
+	err = svc.DB.Create(appPermission).Error
+	assert.NoError(t, err)
+
+	// TODO: AppPermission RequestMethod needs to change to scope
+	appPermission = &db.AppPermission{
+		AppId:         app.ID,
+		RequestMethod: "notifications",
+		ExpiresAt:     nil,
+	}
+	err = svc.DB.Create(appPermission).Error
+	assert.NoError(t, err)
+
+	checkPermission := func(amountMsat uint64) *models.Response {
+		return nil
+	}
+
+	var publishedResponse *models.Response
+
+	publishResponse := func(response *models.Response, tags nostr.Tags) {
+		publishedResponse = response
+	}
+
+	permissionsSvc := permissions.NewPermissionsService(svc.DB, svc.EventPublisher)
+
+	NewGetInfoController(permissionsSvc, svc.LNClient).
+		HandleGetInfoEvent(ctx, nip47Request, dbRequestEvent.ID, app, checkPermission, publishResponse)
+
+	assert.Nil(t, publishedResponse.Error)
+	nodeInfo := publishedResponse.Result.(*getInfoResponse)
+	assert.Equal(t, tests.MockNodeInfo.Alias, nodeInfo.Alias)
+	assert.Equal(t, tests.MockNodeInfo.Color, nodeInfo.Color)
+	assert.Equal(t, tests.MockNodeInfo.Pubkey, nodeInfo.Pubkey)
+	assert.Equal(t, tests.MockNodeInfo.Network, nodeInfo.Network)
+	assert.Equal(t, tests.MockNodeInfo.BlockHeight, nodeInfo.BlockHeight)
+	assert.Equal(t, tests.MockNodeInfo.BlockHash, nodeInfo.BlockHash)
+	assert.Equal(t, []string{"get_info"}, nodeInfo.Methods)
+	assert.Equal(t, []string{"payment_received", "payment_sent"}, nodeInfo.Notifications)
 }

--- a/nip47/notifications/models.go
+++ b/nip47/notifications/models.go
@@ -8,10 +8,14 @@ type Notification struct {
 }
 
 const (
-	NOTIFICATION_TYPES            = "payment_received payment_sent" // e.g. "payment_received payment_sent balance_updated payment_sent channel_opened channel_closed ..."
+	NOTIFICATION_TYPES            = "payment_received payment_sent"
 	PAYMENT_RECEIVED_NOTIFICATION = "payment_received"
 	PAYMENT_SENT_NOTIFICATION     = "payment_sent"
 )
+
+type PaymentSentNotification struct {
+	models.Transaction
+}
 
 type PaymentReceivedNotification struct {
 	models.Transaction

--- a/nip47/notifications/nip47_notifier_test.go
+++ b/nip47/notifications/nip47_notifier_test.go
@@ -44,8 +44,6 @@ func TestSendNotification(t *testing.T) {
 		Event: "nwc_payment_received",
 		Properties: &events.PaymentReceivedEventProperties{
 			PaymentHash: tests.MockPaymentHash,
-			Amount:      uint64(tests.MockTransaction.Amount),
-			NodeType:    "LDK",
 		},
 	}
 
@@ -88,10 +86,7 @@ func TestSendNotification(t *testing.T) {
 	testEvent = &events.Event{
 		Event: "nwc_payment_sent",
 		Properties: &events.PaymentSentEventProperties{
-			PaymentId:   tests.MockPaymentId,
 			PaymentHash: tests.MockPaymentHash,
-			Amount:      uint64(tests.MockTransaction.Amount),
-			NodeType:    "LDK",
 		},
 	}
 
@@ -121,8 +116,6 @@ func TestSendNotificationNoPermission(t *testing.T) {
 		Event: "nwc_payment_received",
 		Properties: &events.PaymentReceivedEventProperties{
 			PaymentHash: tests.MockPaymentHash,
-			Amount:      uint64(tests.MockTransaction.Amount),
-			NodeType:    "LDK",
 		},
 	}
 

--- a/tests/mock_ln_client.go
+++ b/tests/mock_ln_client.go
@@ -13,7 +13,6 @@ const MockPaymentHash500 = "be8ad5d0b82071d538dcd160e3a3af444bd890de68388a4d771b
 
 const MockInvoice = "lntb1230n1pjypux0pp5xgxzcks5jtx06k784f9dndjh664wc08ucrganpqn52d0ftrh9n8sdqyw3jscqzpgxqyz5vqsp5rkx7cq252p3frx8ytjpzc55rkgyx2mfkzzraa272dqvr2j6leurs9qyyssqhutxa24r5hqxstchz5fxlslawprqjnarjujp5sm3xj7ex73s32sn54fthv2aqlhp76qmvrlvxppx9skd3r5ut5xutgrup8zuc6ay73gqmra29m"
 const MockPaymentHash = "320c2c5a1492ccfd5bc7aa4ad9b657d6aaec3cfcc0d1d98413a29af4ac772ccf" // for the above invoice
-const MockPaymentId = "paymentId123"
 
 var MockNodeInfo = lnclient.NodeInfo{
 	Alias:       "bob",


### PR DESCRIPTION
- refactor to better support multiple notification types
- remove unnecessary properties in `payment_received` and `payment_sent` events
- ~~duration is wrong, I need to remove it or rename it (since it's the duration since the invoice was created)~~ - removed the duration property for now
- When originally implementing notifications which was that "notifications" was being returned in the methods parameter of the get_info call and we didn't even include what notification types are supported there (which would be empty if you don't allow the notifications permission).

`get_info` now looks like this:
```
{
  alias: 'NWC',
  color: '#897FFF',
  pubkey: '0219b1a2bf969944e941f72595db5a5dd55531db00972d41bf8099e499dcaea894',
  network: 'signet',
  block_height: 1190784,
  block_hash: '00000043a9e987f7bff8cfb4b5cb3131ddc291c1e8131f889e952f847c4eda17',
  methods: [
    'get_balance',
    'get_info',
    'list_transactions',
    'lookup_invoice',
    'make_invoice',
    'pay_invoice',
    'sign_message',
    'pay_keysend',
    'multi_pay_invoice',
    'multi_pay_keysend'
  ],
  notifications: [ 'payment_received', 'payment_sent' ]
}
```

I think we should prioritize this issue: https://github.com/getAlby/nostr-wallet-connect-next/issues/219