### PR TITLE
feat: hide advanced link if a backend is alrady configured

### DIFF
--- a/frontend/src/screens/Welcome.tsx
+++ b/frontend/src/screens/Welcome.tsx
@@ -51,11 +51,13 @@ export function Welcome() {
             </Button>
           </Link>
 
-          <Link to="/setup/advanced" className="w-full">
-            <Button variant="secondary" className="w-full">
-              Advanced Setup
-            </Button>
-          </Link>
+          {!info?.backendType && (
+            <Link to="/setup/advanced" className="w-full">
+              <Button variant="secondary" className="w-full">
+                Advanced Setup
+              </Button>
+            </Link>
+          )}
         </div>
         <div className="text-sm text-muted-foreground">
           By continuing, you agree to our <br />


### PR DESCRIPTION
if the backend type is already configured through an env variable then
  we likely want to use that one. So the advanced section can be hidden.