### PR TITLE
fix: frequently update fee estimates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/davrux/echo-logrus/v4 v4.0.3
 	github.com/elnosh/gonuts v0.1.1-0.20240602162005-49da741613e4
 	github.com/getAlby/glalby-go v0.0.0-20240616134525-322750d01f8d
-	github.com/getAlby/ldk-node-go v0.0.0-20240624050304-d2810786ce55
+	github.com/getAlby/ldk-node-go v0.0.0-20240624140557-d51c707f10d9
 	github.com/go-gormigrate/gormigrate/v2 v2.1.2
 	github.com/gorilla/sessions v1.2.2
 	github.com/labstack/echo-contrib v0.17.1

--- a/go.sum
+++ b/go.sum
@@ -190,6 +190,8 @@ github.com/getAlby/glalby-go v0.0.0-20240616134525-322750d01f8d h1:ouIUrgIJXgf+f
 github.com/getAlby/glalby-go v0.0.0-20240616134525-322750d01f8d/go.mod h1:ViyJvjlvv0GCesTJ7mb3fBo4G+/qsujDAFN90xZ7a9U=
 github.com/getAlby/ldk-node-go v0.0.0-20240624050304-d2810786ce55 h1:hDsk9Yn2FvxZ0fz/0+7Dv+Xdfha73krDuL8MhG70I6c=
 github.com/getAlby/ldk-node-go v0.0.0-20240624050304-d2810786ce55/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
+github.com/getAlby/ldk-node-go v0.0.0-20240624140557-d51c707f10d9 h1:fxJ8kvYG9gQ0bLQa0N2gCHq2usCB//oLjST+PUMUcnQ=
+github.com/getAlby/ldk-node-go v0.0.0-20240624140557-d51c707f10d9/go.mod h1:8BRjtKcz8E0RyYTPEbMS8VIdgredcGSLne8vHDtcRLg=
 github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -243,7 +243,7 @@ func NewLDKService(ctx context.Context, cfg config.Config, eventPublisher events
 				return
 			case <-time.After(MIN_SYNC_INTERVAL):
 				ls.syncing = true
-				// always update fee rates
+				// always update fee rates to avoid differences in fee rates with channel partners
 				err = node.UpdateFeeEstimates()
 				if err != nil {
 					logger.Logger.WithError(err).Error("Failed to update fee estimates")

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -237,10 +237,17 @@ func NewLDKService(ctx context.Context, cfg config.Config, eventPublisher events
 		MIN_SYNC_INTERVAL := 1 * time.Minute
 		MAX_SYNC_INTERVAL := 1 * time.Hour // NOTE: this could be increased further (possibly to 6 hours)
 		for {
+			ls.syncing = false
 			select {
 			case <-ldkCtx.Done():
 				return
 			case <-time.After(MIN_SYNC_INTERVAL):
+				ls.syncing = true
+				// always update fee rates
+				err = node.UpdateFeeEstimates()
+				if err != nil {
+					logger.Logger.WithError(err).Error("Failed to update fee estimates")
+				}
 
 				if time.Since(ls.lastWalletSyncRequest) > MIN_SYNC_INTERVAL && time.Since(ls.lastSync) < MAX_SYNC_INTERVAL {
 					// logger.Debug("skipping background wallet sync")
@@ -249,9 +256,7 @@ func NewLDKService(ctx context.Context, cfg config.Config, eventPublisher events
 
 				logger.Logger.Info("Starting background wallet sync")
 				syncStartTime := time.Now()
-				ls.syncing = true
 				err = node.SyncWallets()
-				ls.syncing = false
 
 				if err != nil {
 					logger.Logger.WithError(err).Error("Failed to sync LDK wallets")


### PR DESCRIPTION
Fixes https://github.com/getAlby/nostr-wallet-connect-next/issues/496

Updates fee estimates once per minute rather than once per hour by default