### PR TITLE
fix: if version is greater than released version, still mark Alby hub as up to date

### DIFF
--- a/frontend/src/components/layouts/AppLayout.tsx
+++ b/frontend/src/components/layouts/AppLayout.tsx
@@ -181,7 +181,12 @@ export default function AppLayout() {
     );
   }
 
-  const upToDate = info?.version && info.version === info.latestVersion;
+  const upToDate =
+    info?.version &&
+    info.latestVersion &&
+    info.version.startsWith("v") &&
+    info.latestVersion.startsWith("v") &&
+    info.version.substring(1) >= info.latestVersion.substring(1);
 
   return (
     <>


### PR DESCRIPTION
This is the case with the docker builds because they are tagged as latest before the release is published