### PR TITLE
feat: backend-specific capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ If the client creates the secret the client only needs to share the public key o
 - `max_amount` (optional) maximum amount in sats that can be sent per renewal period
 - `budget_renewal` (optional) reset the budget at the end of the given budget renewal. Can be `never` (default), `daily`, `weekly`, `monthly`, `yearly`
 - `request_methods` (optional) url encoded, space separated list of request types that you need permission for: `pay_invoice` (default), `get_balance` (see NIP47). For example: `..&request_methods=pay_invoice%20get_balance`
+- `notification_types` (optional) url encoded, space separated list of notification types that you need permission for: For example: `..&notification_types=payment_received%20payment_sent`
 
 Example:
 

--- a/alby/alby_oauth_service.go
+++ b/alby/alby_oauth_service.go
@@ -9,7 +9,6 @@ import (
 	"math"
 	"net/http"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -388,7 +387,7 @@ func (svc *albyOAuthService) LinkAccount(ctx context.Context, lnClient lnclient.
 		1_000_000,
 		nip47.BUDGET_RENEWAL_MONTHLY,
 		nil,
-		strings.Split(lnClient.GetSupportedNIP47Methods(), " "),
+		lnClient.GetSupportedNIP47Methods(),
 	)
 
 	if err != nil {

--- a/alby/alby_oauth_service.go
+++ b/alby/alby_oauth_service.go
@@ -388,7 +388,7 @@ func (svc *albyOAuthService) LinkAccount(ctx context.Context, lnClient lnclient.
 		1_000_000,
 		nip47.BUDGET_RENEWAL_MONTHLY,
 		nil,
-		strings.Split(lnClient.GetSupportedNIP47Capabilities(), " "),
+		strings.Split(lnClient.GetSupportedNIP47Methods(), " "),
 	)
 
 	if err != nil {

--- a/alby/alby_oauth_service.go
+++ b/alby/alby_oauth_service.go
@@ -375,7 +375,7 @@ func (svc *albyOAuthService) GetAuthUrl() string {
 	return svc.oauthConf.AuthCodeURL("unused")
 }
 
-func (svc *albyOAuthService) LinkAccount(ctx context.Context) error {
+func (svc *albyOAuthService) LinkAccount(ctx context.Context, lnClient lnclient.LNClient) error {
 	connectionPubkey, err := svc.createAlbyAccountNWCNode(ctx)
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to create alby account nwc node")
@@ -388,7 +388,7 @@ func (svc *albyOAuthService) LinkAccount(ctx context.Context) error {
 		1_000_000,
 		nip47.BUDGET_RENEWAL_MONTHLY,
 		nil,
-		strings.Split(nip47.CAPABILITIES, " "),
+		strings.Split(lnClient.GetSupportedNIP47Capabilities(), " "),
 	)
 
 	if err != nil {

--- a/alby/models.go
+++ b/alby/models.go
@@ -13,7 +13,7 @@ type AlbyOAuthService interface {
 	GetAuthUrl() string
 	GetUserIdentifier() (string, error)
 	IsConnected(ctx context.Context) bool
-	LinkAccount(ctx context.Context) error
+	LinkAccount(ctx context.Context, lnClient lnclient.LNClient) error
 	CallbackHandler(ctx context.Context, code string) error
 	GetBalance(ctx context.Context) (*AlbyBalance, error)
 	GetMe(ctx context.Context) (*AlbyMe, error)

--- a/api/api.go
+++ b/api/api.go
@@ -178,7 +178,7 @@ func (api *api) GetApp(userApp *db.App) *App {
 	requestMethods := []string{}
 	for _, appPerm := range appPermissions {
 		expiresAt = appPerm.ExpiresAt
-		if appPerm.Scope == nip47.PAY_INVOICE_METHOD {
+		if appPerm.Scope == permissions.PAY_INVOICE_SCOPE {
 			//find the pay_invoice-specific permissions
 			paySpecificPermission = appPerm
 		}

--- a/api/api.go
+++ b/api/api.go
@@ -194,16 +194,16 @@ func (api *api) GetApp(userApp *db.App) *App {
 	}
 
 	response := App{
-		Name:           userApp.Name,
-		Description:    userApp.Description,
-		CreatedAt:      userApp.CreatedAt,
-		UpdatedAt:      userApp.UpdatedAt,
-		NostrPubkey:    userApp.NostrPubkey,
-		ExpiresAt:      expiresAt,
-		MaxAmount:      maxAmount,
-		RequestMethods: requestMethods,
-		BudgetUsage:    budgetUsage,
-		BudgetRenewal:  paySpecificPermission.BudgetRenewal,
+		Name:          userApp.Name,
+		Description:   userApp.Description,
+		CreatedAt:     userApp.CreatedAt,
+		UpdatedAt:     userApp.UpdatedAt,
+		NostrPubkey:   userApp.NostrPubkey,
+		ExpiresAt:     expiresAt,
+		MaxAmount:     maxAmount,
+		Scopes:        requestMethods,
+		BudgetUsage:   budgetUsage,
+		BudgetRenewal: paySpecificPermission.BudgetRenewal,
 	}
 
 	if lastEventResult.RowsAffected > 0 {
@@ -239,7 +239,7 @@ func (api *api) ListApps() ([]App, error) {
 		}
 
 		for _, appPermission := range permissionsMap[userApp.ID] {
-			apiApp.RequestMethods = append(apiApp.RequestMethods, appPermission.Scope)
+			apiApp.Scopes = append(apiApp.Scopes, appPermission.Scope)
 			apiApp.ExpiresAt = appPermission.ExpiresAt
 			if appPermission.Scope == permissions.PAY_INVOICE_SCOPE {
 				apiApp.BudgetRenewal = appPermission.BudgetRenewal

--- a/api/api.go
+++ b/api/api.go
@@ -689,7 +689,7 @@ func (api *api) GetWalletCapabilities(ctx context.Context) (*WalletCapabilitiesR
 		return nil, err
 	}
 	if len(notificationTypes) > 0 {
-		scopes = append(scopes, "notifications")
+		scopes = append(scopes, permissions.NOTIFICATIONS_SCOPE)
 	}
 
 	return &WalletCapabilitiesResponse{

--- a/api/api.go
+++ b/api/api.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 	"sync"
 	"time"
 
@@ -681,8 +680,8 @@ func (api *api) GetWalletCapabilities(ctx context.Context) (*WalletCapabilitiesR
 		return nil, errors.New("LNClient not started")
 	}
 
-	methods := strings.Split(api.svc.GetLNClient().GetSupportedNIP47Methods(), " ")
-	notificationTypes := strings.Split(api.svc.GetLNClient().GetSupportedNIP47NotificationTypes(), " ")
+	methods := api.svc.GetLNClient().GetSupportedNIP47Methods()
+	notificationTypes := api.svc.GetLNClient().GetSupportedNIP47NotificationTypes()
 
 	scopes, err := permissions.RequestMethodsToScopes(methods)
 	if err != nil {

--- a/api/api.go
+++ b/api/api.go
@@ -20,7 +20,6 @@ import (
 	"github.com/getAlby/nostr-wallet-connect/events"
 	"github.com/getAlby/nostr-wallet-connect/lnclient"
 	"github.com/getAlby/nostr-wallet-connect/logger"
-	nip47 "github.com/getAlby/nostr-wallet-connect/nip47/models"
 	permissions "github.com/getAlby/nostr-wallet-connect/nip47/permissions"
 	"github.com/getAlby/nostr-wallet-connect/service"
 	"github.com/getAlby/nostr-wallet-connect/service/keys"

--- a/api/api.go
+++ b/api/api.go
@@ -684,9 +684,10 @@ func (api *api) GetWalletCapabilities(ctx context.Context) (*WalletCapabilitiesR
 	methods := strings.Split(api.svc.GetLNClient().GetSupportedNIP47Methods(), " ")
 	notificationTypes := strings.Split(api.svc.GetLNClient().GetSupportedNIP47NotificationTypes(), " ")
 
-	scopes := utils.Filter(methods, func(s string) bool {
-		return s != nip47.PAY_KEYSEND_METHOD && s != nip47.MULTI_PAY_INVOICE_METHOD && s != nip47.MULTI_PAY_KEYSEND_METHOD
-	})
+	scopes, err := permissions.RequestMethodsToScopes(methods)
+	if err != nil {
+		return nil, err
+	}
 	if len(notificationTypes) > 0 {
 		scopes = append(scopes, "notifications")
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"sync"
 	"time"
 
@@ -57,6 +58,12 @@ func (api *api) CreateApp(createAppRequest *CreateAppRequest) (*CreateAppRespons
 
 	if len(createAppRequest.Scopes) == 0 {
 		return nil, fmt.Errorf("won't create an app without scopes")
+	}
+
+	for _, scope := range createAppRequest.Scopes {
+		if !slices.Contains(permissions.AllScopes(), scope) {
+			return nil, fmt.Errorf("did not recognize requested scope: %s", scope)
+		}
 	}
 
 	app, pairingSecretKey, err := api.dbSvc.CreateApp(createAppRequest.Name, createAppRequest.Pubkey, createAppRequest.MaxAmount, createAppRequest.BudgetRenewal, expiresAt, createAppRequest.Scopes)

--- a/api/backup.go
+++ b/api/backup.go
@@ -10,7 +10,6 @@ import (
 	"archive/zip"
 	"os"
 	"path/filepath"
-	"slices"
 
 	"crypto/aes"
 	"crypto/cipher"
@@ -19,6 +18,7 @@ import (
 
 	"github.com/getAlby/nostr-wallet-connect/db"
 	"github.com/getAlby/nostr-wallet-connect/logger"
+	"github.com/getAlby/nostr-wallet-connect/utils"
 	"golang.org/x/crypto/pbkdf2"
 )
 
@@ -73,8 +73,8 @@ func (api *api) CreateBackup(unlockPassword string, w io.Writer) error {
 		logger.Logger.WithField("lnFiles", lnFiles).Info("Listed node storage dir")
 
 		// Avoid backing up log files.
-		slices.DeleteFunc(lnFiles, func(s string) bool {
-			return filepath.Ext(s) == ".log"
+		lnFiles = utils.Filter(lnFiles, func(s string) bool {
+			return filepath.Ext(s) != ".log"
 		})
 
 		filesToArchive = append(filesToArchive, lnFiles...)

--- a/api/models.go
+++ b/api/models.go
@@ -76,21 +76,20 @@ type ListAppsResponse struct {
 }
 
 type UpdateAppRequest struct {
-	MaxAmount      uint64 `json:"maxAmount"`
-	BudgetRenewal  string `json:"budgetRenewal"`
-	ExpiresAt      string `json:"expiresAt"`
-	RequestMethods string `json:"requestMethods"`
+	MaxAmount     uint64   `json:"maxAmount"`
+	BudgetRenewal string   `json:"budgetRenewal"`
+	ExpiresAt     string   `json:"expiresAt"`
+	Scopes        []string `json:"scopes"`
 }
 
 type CreateAppRequest struct {
-	Name              string   `json:"name"`
-	Pubkey            string   `json:"pubkey"`
-	MaxAmount         uint64   `json:"maxAmount"`
-	BudgetRenewal     string   `json:"budgetRenewal"`
-	ExpiresAt         string   `json:"expiresAt"`
-	RequestMethods    []string `json:"requestMethods"`
-	NotificationTypes []string `json:"notificationTypes"`
-	ReturnTo          string   `json:"returnTo"`
+	Name          string   `json:"name"`
+	Pubkey        string   `json:"pubkey"`
+	MaxAmount     uint64   `json:"maxAmount"`
+	BudgetRenewal string   `json:"budgetRenewal"`
+	ExpiresAt     string   `json:"expiresAt"`
+	Scopes        []string `json:"scopes"`
+	ReturnTo      string   `json:"returnTo"`
 }
 
 type StartRequest struct {

--- a/api/models.go
+++ b/api/models.go
@@ -63,12 +63,12 @@ type App struct {
 	CreatedAt   time.Time `json:"createdAt"`
 	UpdatedAt   time.Time `json:"updatedAt"`
 
-	LastEventAt    *time.Time `json:"lastEventAt"`
-	ExpiresAt      *time.Time `json:"expiresAt"`
-	RequestMethods []string   `json:"requestMethods"`
-	MaxAmount      uint64     `json:"maxAmount"`
-	BudgetUsage    uint64     `json:"budgetUsage"`
-	BudgetRenewal  string     `json:"budgetRenewal"`
+	LastEventAt   *time.Time `json:"lastEventAt"`
+	ExpiresAt     *time.Time `json:"expiresAt"`
+	Scopes        []string   `json:"scopes"`
+	MaxAmount     uint64     `json:"maxAmount"`
+	BudgetUsage   uint64     `json:"budgetUsage"`
+	BudgetRenewal string     `json:"budgetRenewal"`
 }
 
 type ListAppsResponse struct {

--- a/api/models.go
+++ b/api/models.go
@@ -83,13 +83,14 @@ type UpdateAppRequest struct {
 }
 
 type CreateAppRequest struct {
-	Name           string `json:"name"`
-	Pubkey         string `json:"pubkey"`
-	MaxAmount      uint64 `json:"maxAmount"`
-	BudgetRenewal  string `json:"budgetRenewal"`
-	ExpiresAt      string `json:"expiresAt"`
-	RequestMethods string `json:"requestMethods"`
-	ReturnTo       string `json:"returnTo"`
+	Name              string   `json:"name"`
+	Pubkey            string   `json:"pubkey"`
+	MaxAmount         uint64   `json:"maxAmount"`
+	BudgetRenewal     string   `json:"budgetRenewal"`
+	ExpiresAt         string   `json:"expiresAt"`
+	RequestMethods    []string `json:"requestMethods"`
+	NotificationTypes []string `json:"notificationTypes"`
+	ReturnTo          string   `json:"returnTo"`
 }
 
 type StartRequest struct {
@@ -264,7 +265,7 @@ type NewInstantChannelInvoiceResponse struct {
 }
 
 type WalletCapabilitiesResponse struct {
-	Capabilities               []string `json:"capabilities"`
-	SupportedPermissions       []string `json:"supportedPermissions"`
-	SupportedNotificationTypes []string `json:"supportedNotificationTypes"`
+	Scopes            []string `json:"scopes"`
+	Methods           []string `json:"methods"`
+	NotificationTypes []string `json:"notificationTypes"`
 }

--- a/api/models.go
+++ b/api/models.go
@@ -48,6 +48,7 @@ type API interface {
 	NewInstantChannelInvoice(ctx context.Context, request *NewInstantChannelInvoiceRequest) (*NewInstantChannelInvoiceResponse, error)
 	CreateBackup(unlockPassword string, w io.Writer) error
 	RestoreBackup(unlockPassword string, r io.Reader) error
+	GetWalletCapabilities(ctx context.Context) (*WalletCapabilitiesResponse, error)
 }
 
 type App struct {
@@ -246,4 +247,10 @@ type NewInstantChannelInvoiceResponse struct {
 	InvoiceAmount     uint64 `json:"invoiceAmount"`
 	IncomingLiquidity uint64 `json:"incomingLiquidity"`
 	OutgoingLiquidity uint64 `json:"outgoingLiquidity"`
+}
+
+type WalletCapabilitiesResponse struct {
+	Capabilities               []string `json:"capabilities"`
+	SupportedPermissions       []string `json:"supportedPermissions"`
+	SupportedNotificationTypes []string `json:"supportedNotificationTypes"`
 }

--- a/db/db_service.go
+++ b/db/db_service.go
@@ -20,7 +20,7 @@ func NewDBService(db *gorm.DB) *dbService {
 	}
 }
 
-func (svc *dbService) CreateApp(name string, pubkey string, maxAmount uint64, budgetRenewal string, expiresAt *time.Time, requestMethods []string) (*App, string, error) {
+func (svc *dbService) CreateApp(name string, pubkey string, maxAmount uint64, budgetRenewal string, expiresAt *time.Time, scopes []string) (*App, string, error) {
 	var pairingPublicKey string
 	var pairingSecretKey string
 	if pubkey == "" {
@@ -44,11 +44,11 @@ func (svc *dbService) CreateApp(name string, pubkey string, maxAmount uint64, bu
 			return err
 		}
 
-		for _, m := range requestMethods {
+		for _, scope := range scopes {
 			appPermission := AppPermission{
-				App:           app,
-				RequestMethod: m,
-				ExpiresAt:     expiresAt,
+				App:       app,
+				Scope:     scope,
+				ExpiresAt: expiresAt,
 				//these fields are only relevant for pay_invoice
 				MaxAmount:     int(maxAmount),
 				BudgetRenewal: budgetRenewal,
@@ -58,6 +58,7 @@ func (svc *dbService) CreateApp(name string, pubkey string, maxAmount uint64, bu
 				return err
 			}
 		}
+
 		// commit transaction
 		return nil
 	})

--- a/db/migrations/202406301207_rename_request_methods.go
+++ b/db/migrations/202406301207_rename_request_methods.go
@@ -1,0 +1,22 @@
+package migrations
+
+import (
+	_ "embed"
+
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+var _202406301207_rename_request_methods = &gormigrate.Migration{
+	ID: "202406301207_rename_request_methods",
+	Migrate: func(tx *gorm.DB) error {
+		if err := tx.Exec("ALTER TABLE app_permissions RENAME request_method TO scope").Error; err != nil {
+			return err
+		}
+
+		return nil
+	},
+	Rollback: func(tx *gorm.DB) error {
+		return nil
+	},
+}

--- a/db/migrations/migrate.go
+++ b/db/migrations/migrate.go
@@ -14,6 +14,7 @@ func Migrate(gormDB *gorm.DB) error {
 		_202405302121_store_decrypted_request,
 		_202406061259_delete_content,
 		_202406071726_vacuum,
+		_202406301207_rename_request_methods,
 	})
 
 	return m.Migrate()

--- a/db/models.go
+++ b/db/models.go
@@ -24,7 +24,7 @@ type AppPermission struct {
 	ID            uint
 	AppId         uint `validate:"required"`
 	App           App
-	RequestMethod string `validate:"required"`
+	Scope         string `validate:"required"`
 	MaxAmount     int
 	BudgetRenewal string
 	ExpiresAt     *time.Time
@@ -68,7 +68,7 @@ type Payment struct {
 }
 
 type DBService interface {
-	CreateApp(name string, pubkey string, maxAmount uint64, budgetRenewal string, expiresAt *time.Time, requestMethods []string) (*App, string, error)
+	CreateApp(name string, pubkey string, maxAmount uint64, budgetRenewal string, expiresAt *time.Time, scopes []string) (*App, string, error)
 }
 
 const (

--- a/frontend/src/components/Permissions.tsx
+++ b/frontend/src/components/Permissions.tsx
@@ -60,15 +60,21 @@ const Permissions: React.FC<PermissionsProps> = ({
       return;
     }
 
+    let budgetRenewal = permissions.budgetRenewal;
+
     const newScopes = new Set(permissions.scopes);
     if (newScopes.has(scope)) {
       newScopes.delete(scope);
     } else {
       newScopes.add(scope);
+      if (scope === "pay_invoice") {
+        budgetRenewal = "monthly";
+      }
     }
 
     handlePermissionsChange({
       scopes: newScopes,
+      budgetRenewal,
     });
   };
 
@@ -171,13 +177,11 @@ const Permissions: React.FC<PermissionsProps> = ({
                               <SelectContent>
                                 {validBudgetRenewals.map((renewalOption) => (
                                   <SelectItem
-                                    key={renewalOption || "never"}
-                                    value={renewalOption || "never"}
+                                    key={renewalOption}
+                                    value={renewalOption}
                                   >
-                                    {renewalOption
-                                      ? renewalOption.charAt(0).toUpperCase() +
-                                        renewalOption.slice(1)
-                                      : "Never"}
+                                    {renewalOption.charAt(0).toUpperCase() +
+                                      renewalOption.slice(1)}
                                   </SelectItem>
                                 ))}
                               </SelectContent>

--- a/frontend/src/components/Permissions.tsx
+++ b/frontend/src/components/Permissions.tsx
@@ -10,6 +10,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "src/components/ui/select";
+import { useCapabilities } from "src/hooks/useCapabilities";
 import { cn } from "src/lib/utils";
 import {
   AppPermissions,
@@ -40,6 +41,7 @@ const Permissions: React.FC<PermissionsProps> = ({
   const [permissions, setPermissions] = React.useState(initialPermissions);
   const [days, setDays] = useState(isNewConnection ? 0 : -1);
   const [expireOptions, setExpireOptions] = useState(!isNewConnection);
+  const { data: capabilities } = useCapabilities();
 
   useEffect(() => {
     setPermissions(initialPermissions);
@@ -100,160 +102,150 @@ const Permissions: React.FC<PermissionsProps> = ({
     <div>
       <div className="mb-6">
         <ul className="flex flex-col w-full">
-          {(Object.keys(nip47PermissionDescriptions) as PermissionType[]).map(
-            (rm, index) => {
-              const RequestMethodIcon = iconMap[rm];
-              return (
-                <li
-                  key={index}
-                  className={cn(
-                    "w-full",
-                    rm == "pay_invoice" ? "order-last" : "",
-                    !canEditPermissions && !permissions.requestMethods.has(rm)
-                      ? "hidden"
-                      : ""
-                  )}
-                >
-                  <div className="flex items-center mb-2">
-                    {RequestMethodIcon && (
-                      <RequestMethodIcon
-                        className={cn(
-                          "text-muted-foreground w-4 mr-3",
-                          canEditPermissions ? "hidden" : ""
-                        )}
-                      />
-                    )}
-                    <Checkbox
-                      id={rm}
+          {capabilities?.supportedPermissions.map((rm, index) => {
+            const RequestMethodIcon = iconMap[rm];
+            return (
+              <li
+                key={index}
+                className={cn(
+                  "w-full",
+                  rm == "pay_invoice" ? "order-last" : "",
+                  !canEditPermissions && !permissions.requestMethods.has(rm)
+                    ? "hidden"
+                    : ""
+                )}
+              >
+                <div className="flex items-center mb-2">
+                  {RequestMethodIcon && (
+                    <RequestMethodIcon
                       className={cn(
-                        "mr-2",
-                        !canEditPermissions ? "hidden" : ""
+                        "text-muted-foreground w-4 mr-3",
+                        canEditPermissions ? "hidden" : ""
                       )}
-                      onCheckedChange={() => handleRequestMethodChange(rm)}
-                      checked={permissions.requestMethods.has(rm)}
                     />
-                    <Label
-                      htmlFor={rm}
-                      className={`${canEditPermissions && "cursor-pointer"}`}
-                    >
-                      {nip47PermissionDescriptions[rm]}
-                    </Label>
-                  </div>
-                  {rm == "pay_invoice" && (
-                    <div
-                      className={cn(
-                        "pt-2 pb-2 pl-5 ml-2.5 border-l-2 border-l-primary",
-                        !permissions.requestMethods.has(rm)
-                          ? canEditPermissions
-                            ? "pointer-events-none opacity-30"
-                            : "hidden"
-                          : ""
-                      )}
-                    >
-                      {canEditPermissions ? (
-                        <>
-                          <div className="flex flex-row gap-2 items-center text-muted-foreground mb-3 text-sm capitalize">
-                            <p> Budget Renewal:</p>
-                            {!canEditPermissions ? (
-                              permissions.budgetRenewal
-                            ) : (
-                              <Select
-                                value={permissions.budgetRenewal}
-                                onValueChange={handleBudgetRenewalChange}
-                                disabled={!canEditPermissions}
-                              >
-                                <SelectTrigger className="w-[150px]">
-                                  <SelectValue
-                                    placeholder={permissions.budgetRenewal}
-                                  />
-                                </SelectTrigger>
-                                <SelectContent>
-                                  {validBudgetRenewals.map((renewalOption) => (
-                                    <SelectItem
-                                      key={renewalOption || "never"}
-                                      value={renewalOption || "never"}
-                                    >
-                                      {renewalOption
-                                        ? renewalOption
-                                            .charAt(0)
-                                            .toUpperCase() +
-                                          renewalOption.slice(1)
-                                        : "Never"}
-                                    </SelectItem>
-                                  ))}
-                                </SelectContent>
-                              </Select>
-                            )}
-                          </div>
-                          <div
-                            id="budget-allowance-limits"
-                            className="grid grid-cols-6 grid-rows-2 md:grid-rows-1 md:grid-cols-6 gap-2 text-xs"
-                          >
-                            {Object.keys(budgetOptions).map((budget) => {
-                              return (
-                                // replace with something else and then remove dark prefixes
-                                <div
-                                  key={budget}
-                                  onClick={() =>
-                                    handleMaxAmountChange(budgetOptions[budget])
-                                  }
-                                  className={`col-span-2 md:col-span-1 cursor-pointer rounded border-2 ${
-                                    permissions.maxAmount ==
-                                    budgetOptions[budget]
-                                      ? "border-primary"
-                                      : "border-muted"
-                                  } text-center py-4 dark:text-white`}
-                                >
-                                  {budget}
-                                  <br />
-                                  {budgetOptions[budget] ? "sats" : "#reckless"}
-                                </div>
-                              );
-                            })}
-                          </div>
-                        </>
-                      ) : isNewConnection ? (
-                        <>
-                          <p className="text-muted-foreground text-sm">
-                            <span className="capitalize">
-                              {permissions.budgetRenewal}
-                            </span>{" "}
-                            budget: {permissions.maxAmount} sats
-                          </p>
-                        </>
-                      ) : (
-                        <table className="text-muted-foreground">
-                          <tbody>
-                            <tr className="text-sm">
-                              <td className="pr-2">Budget Allowance:</td>
-                              <td>
-                                {permissions.maxAmount
-                                  ? new Intl.NumberFormat().format(
-                                      permissions.maxAmount
-                                    )
-                                  : "∞"}{" "}
-                                sats (
-                                {new Intl.NumberFormat().format(
-                                  budgetUsage || 0
-                                )}{" "}
-                                sats used)
-                              </td>
-                            </tr>
-                            <tr className="text-sm">
-                              <td className="pr-2">Renews:</td>
-                              <td className="capitalize">
-                                {permissions.budgetRenewal || "Never"}
-                              </td>
-                            </tr>
-                          </tbody>
-                        </table>
-                      )}
-                    </div>
                   )}
-                </li>
-              );
-            }
-          )}
+                  <Checkbox
+                    id={rm}
+                    className={cn("mr-2", !canEditPermissions ? "hidden" : "")}
+                    onCheckedChange={() => handleRequestMethodChange(rm)}
+                    checked={permissions.requestMethods.has(rm)}
+                  />
+                  <Label
+                    htmlFor={rm}
+                    className={`${canEditPermissions && "cursor-pointer"}`}
+                  >
+                    {nip47PermissionDescriptions[rm]}
+                  </Label>
+                </div>
+                {rm == "pay_invoice" && (
+                  <div
+                    className={cn(
+                      "pt-2 pb-2 pl-5 ml-2.5 border-l-2 border-l-primary",
+                      !permissions.requestMethods.has(rm)
+                        ? canEditPermissions
+                          ? "pointer-events-none opacity-30"
+                          : "hidden"
+                        : ""
+                    )}
+                  >
+                    {canEditPermissions ? (
+                      <>
+                        <div className="flex flex-row gap-2 items-center text-muted-foreground mb-3 text-sm capitalize">
+                          <p> Budget Renewal:</p>
+                          {!canEditPermissions ? (
+                            permissions.budgetRenewal
+                          ) : (
+                            <Select
+                              value={permissions.budgetRenewal}
+                              onValueChange={handleBudgetRenewalChange}
+                              disabled={!canEditPermissions}
+                            >
+                              <SelectTrigger className="w-[150px]">
+                                <SelectValue
+                                  placeholder={permissions.budgetRenewal}
+                                />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {validBudgetRenewals.map((renewalOption) => (
+                                  <SelectItem
+                                    key={renewalOption || "never"}
+                                    value={renewalOption || "never"}
+                                  >
+                                    {renewalOption
+                                      ? renewalOption.charAt(0).toUpperCase() +
+                                        renewalOption.slice(1)
+                                      : "Never"}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          )}
+                        </div>
+                        <div
+                          id="budget-allowance-limits"
+                          className="grid grid-cols-6 grid-rows-2 md:grid-rows-1 md:grid-cols-6 gap-2 text-xs"
+                        >
+                          {Object.keys(budgetOptions).map((budget) => {
+                            return (
+                              // replace with something else and then remove dark prefixes
+                              <div
+                                key={budget}
+                                onClick={() =>
+                                  handleMaxAmountChange(budgetOptions[budget])
+                                }
+                                className={`col-span-2 md:col-span-1 cursor-pointer rounded border-2 ${
+                                  permissions.maxAmount == budgetOptions[budget]
+                                    ? "border-primary"
+                                    : "border-muted"
+                                } text-center py-4 dark:text-white`}
+                              >
+                                {budget}
+                                <br />
+                                {budgetOptions[budget] ? "sats" : "#reckless"}
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </>
+                    ) : isNewConnection ? (
+                      <>
+                        <p className="text-muted-foreground text-sm">
+                          <span className="capitalize">
+                            {permissions.budgetRenewal}
+                          </span>{" "}
+                          budget: {permissions.maxAmount} sats
+                        </p>
+                      </>
+                    ) : (
+                      <table className="text-muted-foreground">
+                        <tbody>
+                          <tr className="text-sm">
+                            <td className="pr-2">Budget Allowance:</td>
+                            <td>
+                              {permissions.maxAmount
+                                ? new Intl.NumberFormat().format(
+                                    permissions.maxAmount
+                                  )
+                                : "∞"}{" "}
+                              sats (
+                              {new Intl.NumberFormat().format(budgetUsage || 0)}{" "}
+                              sats used)
+                            </td>
+                          </tr>
+                          <tr className="text-sm">
+                            <td className="pr-2">Renews:</td>
+                            <td className="capitalize">
+                              {permissions.budgetRenewal || "Never"}
+                            </td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    )}
+                  </div>
+                )}
+              </li>
+            );
+          })}
         </ul>
       </div>
 

--- a/frontend/src/components/Permissions.tsx
+++ b/frontend/src/components/Permissions.tsx
@@ -15,8 +15,6 @@ import { cn } from "src/lib/utils";
 import {
   AppPermissions,
   BudgetRenewalType,
-  Nip47NotificationType,
-  Nip47RequestMethod,
   Scope,
   budgetOptions,
   expiryOptions,
@@ -57,51 +55,20 @@ const Permissions: React.FC<PermissionsProps> = ({
     onPermissionsChange(updatedPermissions);
   };
 
-  const toScopes = (
-    _requestMethods: Set<Nip47RequestMethod>,
-    _notificationTypes: Set<Nip47NotificationType>
-  ): Set<Scope> => {
-    throw new Error("TODO - map should come from backend");
-  };
-
   const handleScopeChange = (scope: Scope) => {
     if (!canEditPermissions) {
       return;
     }
 
-    const scopeToRequestMethods = (_scope: Scope): Nip47RequestMethod[] => {
-      throw new Error("TODO - map should come from backend");
-    };
-    const scopeToNotificationTypes = (
-      _scope: Scope
-    ): Nip47NotificationType[] => {
-      throw new Error("TODO - map should come from backend");
-    };
-
-    const scopeRequestMethods = scopeToRequestMethods(scope);
-    const scopeNotificationTypes = scopeToNotificationTypes(scope);
-
-    const newRequestMethods = new Set(permissions.requestMethods);
-    for (const method of scopeRequestMethods) {
-      if (newRequestMethods.has(method)) {
-        newRequestMethods.delete(method);
-      } else {
-        newRequestMethods.add(method);
-      }
-    }
-
-    const newNotificationTypes = new Set(permissions.notificationTypes);
-    for (const notificationType of scopeNotificationTypes) {
-      if (newNotificationTypes.has(notificationType)) {
-        newNotificationTypes.delete(notificationType);
-      } else {
-        newNotificationTypes.add(notificationType);
-      }
+    const newScopes = new Set(permissions.scopes);
+    if (newScopes.has(scope)) {
+      newScopes.delete(scope);
+    } else {
+      newScopes.add(scope);
     }
 
     handlePermissionsChange({
-      requestMethods: newRequestMethods,
-      notificationTypes: newNotificationTypes,
+      scopes: newScopes,
     });
   };
 
@@ -146,9 +113,9 @@ const Permissions: React.FC<PermissionsProps> = ({
                 className={cn(
                   "w-full",
                   scope == "pay_invoice" ? "order-last" : "",
-                  /*!canEditPermissions && !permissions.requestMethods.has(rm)
+                  !canEditPermissions && !permissions.scopes.has(scope)
                     ? "hidden"
-                    : */ ""
+                    : ""
                 )}
               >
                 <div className="flex items-center mb-2">
@@ -164,10 +131,7 @@ const Permissions: React.FC<PermissionsProps> = ({
                     id={scope}
                     className={cn("mr-2", !canEditPermissions ? "hidden" : "")}
                     onCheckedChange={() => handleScopeChange(scope)}
-                    checked={toScopes(
-                      permissions.requestMethods,
-                      permissions.notificationTypes
-                    ).has(scope)}
+                    checked={permissions.scopes.has(scope)}
                   />
                   <Label
                     htmlFor={scope}
@@ -180,7 +144,7 @@ const Permissions: React.FC<PermissionsProps> = ({
                   <div
                     className={cn(
                       "pt-2 pb-2 pl-5 ml-2.5 border-l-2 border-l-primary",
-                      !permissions.requestMethods.has(scope)
+                      !permissions.scopes.has(scope)
                         ? canEditPermissions
                           ? "pointer-events-none opacity-30"
                           : "hidden"

--- a/frontend/src/components/Permissions.tsx
+++ b/frontend/src/components/Permissions.tsx
@@ -15,11 +15,13 @@ import { cn } from "src/lib/utils";
 import {
   AppPermissions,
   BudgetRenewalType,
-  PermissionType,
+  Nip47NotificationType,
+  Nip47RequestMethod,
+  Scope,
   budgetOptions,
   expiryOptions,
   iconMap,
-  nip47PermissionDescriptions,
+  scopeDescriptions,
   validBudgetRenewals,
 } from "src/types";
 
@@ -55,18 +57,52 @@ const Permissions: React.FC<PermissionsProps> = ({
     onPermissionsChange(updatedPermissions);
   };
 
-  const handleRequestMethodChange = (requestMethod: PermissionType) => {
+  const toScopes = (
+    _requestMethods: Set<Nip47RequestMethod>,
+    _notificationTypes: Set<Nip47NotificationType>
+  ): Set<Scope> => {
+    throw new Error("TODO - map should come from backend");
+  };
+
+  const handleScopeChange = (scope: Scope) => {
     if (!canEditPermissions) {
       return;
     }
 
+    const scopeToRequestMethods = (_scope: Scope): Nip47RequestMethod[] => {
+      throw new Error("TODO - map should come from backend");
+    };
+    const scopeToNotificationTypes = (
+      _scope: Scope
+    ): Nip47NotificationType[] => {
+      throw new Error("TODO - map should come from backend");
+    };
+
+    const scopeRequestMethods = scopeToRequestMethods(scope);
+    const scopeNotificationTypes = scopeToNotificationTypes(scope);
+
     const newRequestMethods = new Set(permissions.requestMethods);
-    if (newRequestMethods.has(requestMethod)) {
-      newRequestMethods.delete(requestMethod);
-    } else {
-      newRequestMethods.add(requestMethod);
+    for (const method of scopeRequestMethods) {
+      if (newRequestMethods.has(method)) {
+        newRequestMethods.delete(method);
+      } else {
+        newRequestMethods.add(method);
+      }
     }
-    handlePermissionsChange({ requestMethods: newRequestMethods });
+
+    const newNotificationTypes = new Set(permissions.notificationTypes);
+    for (const notificationType of scopeNotificationTypes) {
+      if (newNotificationTypes.has(notificationType)) {
+        newNotificationTypes.delete(notificationType);
+      } else {
+        newNotificationTypes.add(notificationType);
+      }
+    }
+
+    handlePermissionsChange({
+      requestMethods: newRequestMethods,
+      notificationTypes: newNotificationTypes,
+    });
   };
 
   const handleMaxAmountChange = (amount: number) => {
@@ -102,22 +138,22 @@ const Permissions: React.FC<PermissionsProps> = ({
     <div>
       <div className="mb-6">
         <ul className="flex flex-col w-full">
-          {capabilities?.supportedPermissions.map((rm, index) => {
-            const RequestMethodIcon = iconMap[rm];
+          {capabilities?.scopes.map((scope, index) => {
+            const ScopeIcon = iconMap[scope];
             return (
               <li
                 key={index}
                 className={cn(
                   "w-full",
-                  rm == "pay_invoice" ? "order-last" : "",
-                  !canEditPermissions && !permissions.requestMethods.has(rm)
+                  scope == "pay_invoice" ? "order-last" : "",
+                  /*!canEditPermissions && !permissions.requestMethods.has(rm)
                     ? "hidden"
-                    : ""
+                    : */ ""
                 )}
               >
                 <div className="flex items-center mb-2">
-                  {RequestMethodIcon && (
-                    <RequestMethodIcon
+                  {ScopeIcon && (
+                    <ScopeIcon
                       className={cn(
                         "text-muted-foreground w-4 mr-3",
                         canEditPermissions ? "hidden" : ""
@@ -125,23 +161,26 @@ const Permissions: React.FC<PermissionsProps> = ({
                     />
                   )}
                   <Checkbox
-                    id={rm}
+                    id={scope}
                     className={cn("mr-2", !canEditPermissions ? "hidden" : "")}
-                    onCheckedChange={() => handleRequestMethodChange(rm)}
-                    checked={permissions.requestMethods.has(rm)}
+                    onCheckedChange={() => handleScopeChange(scope)}
+                    checked={toScopes(
+                      permissions.requestMethods,
+                      permissions.notificationTypes
+                    ).has(scope)}
                   />
                   <Label
-                    htmlFor={rm}
+                    htmlFor={scope}
                     className={`${canEditPermissions && "cursor-pointer"}`}
                   >
-                    {nip47PermissionDescriptions[rm]}
+                    {scopeDescriptions[scope]}
                   </Label>
                 </div>
-                {rm == "pay_invoice" && (
+                {scope == "pay_invoice" && (
                   <div
                     className={cn(
                       "pt-2 pb-2 pl-5 ml-2.5 border-l-2 border-l-primary",
-                      !permissions.requestMethods.has(rm)
+                      !permissions.requestMethods.has(scope)
                         ? canEditPermissions
                           ? "pointer-events-none opacity-30"
                           : "hidden"

--- a/frontend/src/components/connections/AppCardConnectionInfo.tsx
+++ b/frontend/src/components/connections/AppCardConnectionInfo.tsx
@@ -55,7 +55,7 @@ export function AppCardConnectionInfo({
             </div>
           )}
         </>
-      ) : connection.requestMethods.indexOf("pay_invoice") > -1 ? (
+      ) : connection.scopes.indexOf("pay_invoice") > -1 ? (
         <>
           <div className="flex flex-row justify-between">
             <div className="mb-2">

--- a/frontend/src/hooks/useCapabilities.ts
+++ b/frontend/src/hooks/useCapabilities.ts
@@ -1,0 +1,8 @@
+import useSWR from "swr";
+
+import { WalletCapabilities } from "src/types";
+import { swrFetcher } from "src/utils/swr";
+
+export function useCapabilities() {
+  return useSWR<WalletCapabilities>("/api/wallet/capabilities", swrFetcher);
+}

--- a/frontend/src/screens/apps/NewApp.tsx
+++ b/frontend/src/screens/apps/NewApp.tsx
@@ -103,7 +103,7 @@ const NewAppInternal = ({ capabilities }: NewAppInternalProps) => {
     );
     if (unsupportedNotificationTypes.length) {
       setUnsupportedError(
-        "This app requests methods not supported by your wallet: " +
+        "This app requests notification types not supported by your wallet: " +
           unsupportedNotificationTypes
       );
     }

--- a/frontend/src/screens/apps/ShowApp.tsx
+++ b/frontend/src/screens/apps/ShowApp.tsx
@@ -5,7 +5,13 @@ import { useApp } from "src/hooks/useApp";
 import { useCSRF } from "src/hooks/useCSRF";
 import { useDeleteApp } from "src/hooks/useDeleteApp";
 import { useInfo } from "src/hooks/useInfo";
-import { AppPermissions, BudgetRenewalType, PermissionType } from "src/types";
+import {
+  AppPermissions,
+  BudgetRenewalType,
+  Nip47NotificationType,
+  Nip47RequestMethod,
+  Scope,
+} from "src/types";
 
 import { handleRequestError } from "src/utils/handleRequestError";
 import { request } from "src/utils/request"; // build the project for this to appear
@@ -50,16 +56,29 @@ function ShowApp() {
   });
 
   const [permissions, setPermissions] = React.useState<AppPermissions>({
-    requestMethods: new Set<PermissionType>(),
+    requestMethods: new Set<Nip47RequestMethod>(),
+    notificationTypes: new Set<Nip47NotificationType>(),
     maxAmount: 0,
     budgetRenewal: "",
     expiresAt: undefined,
   });
 
   React.useEffect(() => {
+    const scopesToRequestMethods = (
+      _scopes: Scope[]
+    ): Set<Nip47RequestMethod> => {
+      throw new Error("TODO - map should come from backend");
+    };
+    const scopesToNotificationTypes = (
+      _scopes: Scope[]
+    ): Set<Nip47NotificationType> => {
+      throw new Error("TODO - map should come from backend");
+    };
+
     if (app) {
       setPermissions({
-        requestMethods: new Set(app.requestMethods as PermissionType[]),
+        requestMethods: scopesToRequestMethods(app.scopes),
+        notificationTypes: scopesToNotificationTypes(app.scopes),
         maxAmount: app.maxAmount,
         budgetRenewal: app.budgetRenewal as BudgetRenewalType,
         expiresAt: app.expiresAt ? new Date(app.expiresAt) : undefined,
@@ -195,9 +214,9 @@ function ShowApp() {
                           type="button"
                           variant="outline"
                           onClick={() => {
-                            setPermissions({
+                            /*setPermissions({
                               requestMethods: new Set(
-                                app.requestMethods as PermissionType[]
+                                app.requestMethods as Scope[]
                               ),
                               maxAmount: app.maxAmount,
                               budgetRenewal:
@@ -205,7 +224,7 @@ function ShowApp() {
                               expiresAt: app.expiresAt
                                 ? new Date(app.expiresAt)
                                 : undefined,
-                            });
+                            });*/
                             setEditMode(!editMode);
                             // TODO: clicking cancel and then editing again will leave the days option wrong
                           }}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -45,10 +45,17 @@ export type BudgetRenewalType =
   | "never"
   | "";
 
+// TODO: permissions is not the same as request methods (one payment permission gives multiple request methods)
 // TODO: move other permissions
 export type PermissionType =
   | RequestMethodType
   | typeof NIP_47_NOTIFICATIONS_PERMISSION;
+
+export type Nip47Capability =
+  | RequestMethodType
+  | typeof NIP_47_NOTIFICATIONS_PERMISSION;
+
+export type Nip47NotificationType = "payment_received" | "payment_sent";
 
 export type IconMap = {
   [key in PermissionType]: LucideIcon;
@@ -65,6 +72,12 @@ export const iconMap: IconMap = {
   [NIP_47_NOTIFICATIONS_PERMISSION]: Bell,
 };
 
+export type WalletCapabilities = {
+  capabilities: Nip47Capability[];
+  supportedPermissions: PermissionType[];
+  supportedNotificationTypes: Nip47NotificationType[];
+};
+
 export const validBudgetRenewals: BudgetRenewalType[] = [
   "daily",
   "weekly",
@@ -76,7 +89,7 @@ export const validBudgetRenewals: BudgetRenewalType[] = [
 export const nip47MethodDescriptions: Record<RequestMethodType, string> = {
   [NIP_47_GET_BALANCE_METHOD]: "Read your balance",
   [NIP_47_GET_INFO_METHOD]: "Read your node info",
-  [NIP_47_LIST_TRANSACTIONS_METHOD]: "Read incoming transaction history",
+  [NIP_47_LIST_TRANSACTIONS_METHOD]: "Read transaction history",
   [NIP_47_LOOKUP_INVOICE_METHOD]: "Lookup status of invoices",
   [NIP_47_MAKE_INVOICE_METHOD]: "Create invoices",
   [NIP_47_PAY_INVOICE_METHOD]: "Send payments",

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -138,8 +138,7 @@ export interface App {
 }
 
 export interface AppPermissions {
-  requestMethods: Set<Nip47RequestMethod>;
-  notificationTypes: Set<Nip47NotificationType>;
+  scopes: Set<Scope>;
   maxAmount: number;
   budgetRenewal: BudgetRenewalType;
   expiresAt?: Date;
@@ -172,8 +171,7 @@ export interface CreateAppRequest {
   maxAmount: number;
   budgetRenewal: string;
   expiresAt: string | undefined;
-  requestMethods: Nip47RequestMethod[];
-  notificationTypes: Nip47NotificationType[];
+  scopes: Scope[];
   returnTo: string;
 }
 
@@ -184,6 +182,13 @@ export interface CreateAppResponse {
   pairingSecretKey: string;
   returnTo: string;
 }
+
+export type UpdateAppRequest = {
+  maxAmount: number;
+  budgetRenewal: string;
+  expiresAt: string | undefined;
+  scopes: string[];
+};
 
 export type Channel = {
   localBalance: number;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -187,7 +187,7 @@ export type UpdateAppRequest = {
   maxAmount: number;
   budgetRenewal: string;
   expiresAt: string | undefined;
-  scopes: string[];
+  scopes: Scope[];
 };
 
 export type Channel = {

--- a/http/alby_http_service.go
+++ b/http/alby_http_service.go
@@ -119,7 +119,7 @@ func (albyHttpSvc *AlbyHttpService) albyDrainHandler(c echo.Context) error {
 }
 
 func (albyHttpSvc *AlbyHttpService) albyLinkAccountHandler(c echo.Context) error {
-	err := albyHttpSvc.albyOAuthSvc.LinkAccount(c.Request().Context())
+	err := albyHttpSvc.albyOAuthSvc.LinkAccount(c.Request().Context(), albyHttpSvc.svc.GetLNClient())
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to connect alby account")
 		return err

--- a/http/http_service.go
+++ b/http/http_service.go
@@ -105,6 +105,7 @@ func (httpSvc *HttpService) RegisterSharedRoutes(e *echo.Echo) {
 	e.POST("/api/wallet/redeem-onchain-funds", httpSvc.redeemOnchainFundsHandler, authMiddleware)
 	e.POST("/api/wallet/sign-message", httpSvc.signMessageHandler, authMiddleware)
 	e.POST("/api/wallet/sync", httpSvc.walletSyncHandler, authMiddleware)
+	e.GET("/api/wallet/capabilities", httpSvc.capabilitiesHandler, authMiddleware)
 	e.GET("/api/balances", httpSvc.balancesHandler, authMiddleware)
 	e.POST("/api/reset-router", httpSvc.resetRouterHandler, authMiddleware)
 	e.POST("/api/stop", httpSvc.stopHandler, authMiddleware)
@@ -411,6 +412,18 @@ func (httpSvc *HttpService) mempoolApiHandler(c echo.Context) error {
 		logger.Logger.WithField("endpoint", endpoint).WithError(err).Error("Failed to request mempool API")
 		return c.JSON(http.StatusInternalServerError, ErrorResponse{
 			Message: fmt.Sprintf("Failed to request mempool API: %s", err.Error()),
+		})
+	}
+
+	return c.JSON(http.StatusOK, response)
+}
+
+func (httpSvc *HttpService) capabilitiesHandler(c echo.Context) error {
+	response, err := httpSvc.api.GetWalletCapabilities(c.Request().Context())
+	if err != nil {
+		logger.Logger.WithError(err).Error("Failed to request wallet capabilities")
+		return c.JSON(http.StatusInternalServerError, ErrorResponse{
+			Message: fmt.Sprintf("Failed to request wallet capabilities: %s", err.Error()),
 		})
 	}
 

--- a/lnclient/breez/breez.go
+++ b/lnclient/breez/breez.go
@@ -474,10 +474,10 @@ func (bs *BreezService) DisconnectPeer(ctx context.Context, peerId string) error
 	return nil
 }
 
-func (bs *BreezService) GetSupportedNIP47Methods() string {
-	return "pay_invoice pay_keysend get_balance get_info make_invoice lookup_invoice list_transactions multi_pay_invoice multi_pay_keysend sign_message"
+func (bs *BreezService) GetSupportedNIP47Methods() []string {
+	return []string{"pay_invoice", "pay_keysend", "get_balance", "get_info", "make_invoice", "lookup_invoice", "list_transactions", "multi_pay_invoice", "multi_pay_keysend", "sign_message"}
 }
 
-func (bs *BreezService) GetSupportedNIP47NotificationTypes() string {
-	return ""
+func (bs *BreezService) GetSupportedNIP47NotificationTypes() []string {
+	return []string{}
 }

--- a/lnclient/breez/breez.go
+++ b/lnclient/breez/breez.go
@@ -469,3 +469,11 @@ func (bs *BreezService) UpdateChannel(ctx context.Context, updateChannelRequest 
 func (bs *BreezService) DisconnectPeer(ctx context.Context, peerId string) error {
 	return nil
 }
+
+func (bs *BreezService) GetSupportedNIP47Capabilities() string {
+	return "pay_invoice pay_keysend get_balance get_info make_invoice lookup_invoice list_transactions multi_pay_invoice multi_pay_keysend sign_message"
+}
+
+func (bs *BreezService) GetSupportedNIP47NotificationTypes() string {
+	return ""
+}

--- a/lnclient/breez/breez.go
+++ b/lnclient/breez/breez.go
@@ -474,7 +474,7 @@ func (bs *BreezService) DisconnectPeer(ctx context.Context, peerId string) error
 	return nil
 }
 
-func (bs *BreezService) GetSupportedNIP47Capabilities() string {
+func (bs *BreezService) GetSupportedNIP47Methods() string {
 	return "pay_invoice pay_keysend get_balance get_info make_invoice lookup_invoice list_transactions multi_pay_invoice multi_pay_keysend sign_message"
 }
 

--- a/lnclient/cashu/cashu.go
+++ b/lnclient/cashu/cashu.go
@@ -345,7 +345,7 @@ func (cs *CashuService) checkInvoice(cashuInvoice *storage.Invoice) {
 	}
 }
 
-func (cs *CashuService) GetSupportedNIP47Capabilities() string {
+func (cs *CashuService) GetSupportedNIP47Methods() string {
 	return "pay_invoice get_balance get_info make_invoice lookup_invoice list_transactions multi_pay_invoice"
 }
 

--- a/lnclient/cashu/cashu.go
+++ b/lnclient/cashu/cashu.go
@@ -345,10 +345,10 @@ func (cs *CashuService) checkInvoice(cashuInvoice *storage.Invoice) {
 	}
 }
 
-func (cs *CashuService) GetSupportedNIP47Methods() string {
-	return "pay_invoice get_balance get_info make_invoice lookup_invoice list_transactions multi_pay_invoice"
+func (cs *CashuService) GetSupportedNIP47Methods() []string {
+	return []string{"pay_invoice", "get_balance", "get_info", "make_invoice", "lookup_invoice", "list_transactions", "multi_pay_invoice"}
 }
 
-func (cs *CashuService) GetSupportedNIP47NotificationTypes() string {
-	return ""
+func (cs *CashuService) GetSupportedNIP47NotificationTypes() []string {
+	return []string{}
 }

--- a/lnclient/cashu/cashu.go
+++ b/lnclient/cashu/cashu.go
@@ -340,3 +340,11 @@ func (cs *CashuService) checkInvoice(cashuInvoice *storage.Invoice) {
 		}
 	}
 }
+
+func (cs *CashuService) GetSupportedNIP47Capabilities() string {
+	return "pay_invoice get_balance get_info make_invoice lookup_invoice list_transactions multi_pay_invoice"
+}
+
+func (cs *CashuService) GetSupportedNIP47NotificationTypes() string {
+	return ""
+}

--- a/lnclient/greenlight/greenlight.go
+++ b/lnclient/greenlight/greenlight.go
@@ -676,10 +676,10 @@ func (gs *GreenlightService) DisconnectPeer(ctx context.Context, peerId string) 
 	return nil
 }
 
-func (gs *GreenlightService) GetSupportedNIP47Methods() string {
-	return "pay_invoice pay_keysend get_balance get_info make_invoice lookup_invoice list_transactions multi_pay_invoice multi_pay_keysend sign_message"
+func (gs *GreenlightService) GetSupportedNIP47Methods() []string {
+	return []string{"pay_invoice", "pay_keysend", "get_balance", "get_info", "make_invoice", "lookup_invoice", "list_transactions", "multi_pay_invoice", "multi_pay_keysend", "sign_message"}
 }
 
-func (gs *GreenlightService) GetSupportedNIP47NotificationTypes() string {
-	return ""
+func (gs *GreenlightService) GetSupportedNIP47NotificationTypes() []string {
+	return []string{}
 }

--- a/lnclient/greenlight/greenlight.go
+++ b/lnclient/greenlight/greenlight.go
@@ -671,3 +671,11 @@ func (gs *GreenlightService) UpdateChannel(ctx context.Context, updateChannelReq
 func (gs *GreenlightService) DisconnectPeer(ctx context.Context, peerId string) error {
 	return nil
 }
+
+func (gs *GreenlightService) GetSupportedNIP47Capabilities() string {
+	return "pay_invoice pay_keysend get_balance get_info make_invoice lookup_invoice list_transactions multi_pay_invoice multi_pay_keysend sign_message"
+}
+
+func (gs *GreenlightService) GetSupportedNIP47NotificationTypes() string {
+	return ""
+}

--- a/lnclient/greenlight/greenlight.go
+++ b/lnclient/greenlight/greenlight.go
@@ -676,7 +676,7 @@ func (gs *GreenlightService) DisconnectPeer(ctx context.Context, peerId string) 
 	return nil
 }
 
-func (gs *GreenlightService) GetSupportedNIP47Capabilities() string {
+func (gs *GreenlightService) GetSupportedNIP47Methods() string {
 	return "pay_invoice pay_keysend get_balance get_info make_invoice lookup_invoice list_transactions multi_pay_invoice multi_pay_keysend sign_message"
 }
 

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -1406,8 +1406,8 @@ func (ls *LDKService) UpdateLastWalletSyncRequest() {
 	ls.lastWalletSyncRequest = time.Now()
 }
 
-func (ls *LDKService) GetSupportedNIP47Capabilities() string {
-	return "pay_invoice pay_keysend get_balance get_info make_invoice lookup_invoice list_transactions multi_pay_invoice multi_pay_keysend sign_message notifications"
+func (ls *LDKService) GetSupportedNIP47Methods() string {
+	return "pay_invoice pay_keysend get_balance get_info make_invoice lookup_invoice list_transactions multi_pay_invoice multi_pay_keysend sign_message"
 }
 
 func (ls *LDKService) GetSupportedNIP47NotificationTypes() string {

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -1401,6 +1401,14 @@ func (ls *LDKService) UpdateLastWalletSyncRequest() {
 	ls.lastWalletSyncRequest = time.Now()
 }
 
+func (ls *LDKService) GetSupportedNIP47Capabilities() string {
+	return "pay_invoice pay_keysend get_balance get_info make_invoice lookup_invoice list_transactions multi_pay_invoice multi_pay_keysend sign_message notifications"
+}
+
+func (ls *LDKService) GetSupportedNIP47NotificationTypes() string {
+	return "payment_received payment_sent"
+}
+
 func (ls *LDKService) getChannelCloseReason(event *ldk_node.EventChannelClosed) string {
 	var reason string
 

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -1406,12 +1406,12 @@ func (ls *LDKService) UpdateLastWalletSyncRequest() {
 	ls.lastWalletSyncRequest = time.Now()
 }
 
-func (ls *LDKService) GetSupportedNIP47Methods() string {
-	return "pay_invoice pay_keysend get_balance get_info make_invoice lookup_invoice list_transactions multi_pay_invoice multi_pay_keysend sign_message"
+func (ls *LDKService) GetSupportedNIP47Methods() []string {
+	return []string{"pay_invoice", "pay_keysend", "get_balance", "get_info", "make_invoice", "lookup_invoice", "list_transactions", "multi_pay_invoice", "multi_pay_keysend", "sign_message"}
 }
 
-func (ls *LDKService) GetSupportedNIP47NotificationTypes() string {
-	return "payment_received payment_sent"
+func (ls *LDKService) GetSupportedNIP47NotificationTypes() []string {
+	return []string{"payment_received", "payment_sent"}
 }
 
 func (ls *LDKService) getChannelCloseReason(event *ldk_node.EventChannelClosed) string {

--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -802,7 +802,7 @@ func (svc *LNDService) DisconnectPeer(ctx context.Context, peerId string) error 
 	return nil
 }
 
-func (svc *LNDService) GetSupportedNIP47Capabilities() string {
+func (svc *LNDService) GetSupportedNIP47Methods() string {
 	return "pay_invoice pay_keysend get_balance get_info make_invoice lookup_invoice list_transactions multi_pay_invoice multi_pay_keysend sign_message"
 }
 

--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -802,10 +802,12 @@ func (svc *LNDService) DisconnectPeer(ctx context.Context, peerId string) error 
 	return nil
 }
 
-func (svc *LNDService) GetSupportedNIP47Methods() string {
-	return "pay_invoice pay_keysend get_balance get_info make_invoice lookup_invoice list_transactions multi_pay_invoice multi_pay_keysend sign_message"
+func (svc *LNDService) GetSupportedNIP47Methods() []string {
+	return []string{
+		"pay_invoice", "pay_keysend", "get_balance", "get_info", "make_invoice", "lookup_invoice", "list_transactions", "multi_pay_invoice", "multi_pay_keysend", "sign_message",
+	}
 }
 
-func (svc *LNDService) GetSupportedNIP47NotificationTypes() string {
-	return ""
+func (svc *LNDService) GetSupportedNIP47NotificationTypes() []string {
+	return []string{}
 }

--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -794,3 +794,11 @@ func (svc *LNDService) UpdateChannel(ctx context.Context, updateChannelRequest *
 func (svc *LNDService) DisconnectPeer(ctx context.Context, peerId string) error {
 	return nil
 }
+
+func (svc *LNDService) GetSupportedNIP47Capabilities() string {
+	return "pay_invoice pay_keysend get_balance get_info make_invoice lookup_invoice list_transactions multi_pay_invoice multi_pay_keysend sign_message"
+}
+
+func (svc *LNDService) GetSupportedNIP47NotificationTypes() string {
+	return ""
+}

--- a/lnclient/models.go
+++ b/lnclient/models.go
@@ -71,7 +71,7 @@ type LNClient interface {
 	GetStorageDir() (string, error)
 	GetNetworkGraph(nodeIds []string) (NetworkGraphResponse, error)
 	UpdateLastWalletSyncRequest()
-	GetSupportedNIP47Capabilities() string
+	GetSupportedNIP47Methods() string
 	GetSupportedNIP47NotificationTypes() string
 }
 

--- a/lnclient/models.go
+++ b/lnclient/models.go
@@ -71,6 +71,7 @@ type LNClient interface {
 	GetStorageDir() (string, error)
 	GetNetworkGraph(nodeIds []string) (NetworkGraphResponse, error)
 	UpdateLastWalletSyncRequest()
+	// TODO: change the below to return arrays instead of space-separated strings
 	GetSupportedNIP47Methods() string
 	GetSupportedNIP47NotificationTypes() string
 }

--- a/lnclient/models.go
+++ b/lnclient/models.go
@@ -71,6 +71,8 @@ type LNClient interface {
 	GetStorageDir() (string, error)
 	GetNetworkGraph(nodeIds []string) (NetworkGraphResponse, error)
 	UpdateLastWalletSyncRequest()
+	GetSupportedNIP47Capabilities() string
+	GetSupportedNIP47NotificationTypes() string
 }
 
 type Channel struct {

--- a/lnclient/models.go
+++ b/lnclient/models.go
@@ -71,9 +71,8 @@ type LNClient interface {
 	GetStorageDir() (string, error)
 	GetNetworkGraph(nodeIds []string) (NetworkGraphResponse, error)
 	UpdateLastWalletSyncRequest()
-	// TODO: change the below to return arrays instead of space-separated strings
-	GetSupportedNIP47Methods() string
-	GetSupportedNIP47NotificationTypes() string
+	GetSupportedNIP47Methods() []string
+	GetSupportedNIP47NotificationTypes() []string
 }
 
 type Channel struct {

--- a/lnclient/phoenixd/phoenixd.go
+++ b/lnclient/phoenixd/phoenixd.go
@@ -519,7 +519,7 @@ func (svc *PhoenixService) UpdateChannel(ctx context.Context, updateChannelReque
 	return nil
 }
 
-func (svc *PhoenixService) GetSupportedNIP47Capabilities() string {
+func (svc *PhoenixService) GetSupportedNIP47Methods() string {
 	return "pay_invoice get_balance get_info make_invoice lookup_invoice list_transactions multi_pay_invoice"
 }
 

--- a/lnclient/phoenixd/phoenixd.go
+++ b/lnclient/phoenixd/phoenixd.go
@@ -519,10 +519,10 @@ func (svc *PhoenixService) UpdateChannel(ctx context.Context, updateChannelReque
 	return nil
 }
 
-func (svc *PhoenixService) GetSupportedNIP47Methods() string {
-	return "pay_invoice get_balance get_info make_invoice lookup_invoice list_transactions multi_pay_invoice"
+func (svc *PhoenixService) GetSupportedNIP47Methods() []string {
+	return []string{"pay_invoice", "get_balance", "get_info", "make_invoice", "lookup_invoice", "list_transactions", "multi_pay_invoice"}
 }
 
-func (svc *PhoenixService) GetSupportedNIP47NotificationTypes() string {
-	return ""
+func (svc *PhoenixService) GetSupportedNIP47NotificationTypes() []string {
+	return []string{}
 }

--- a/lnclient/phoenixd/phoenixd.go
+++ b/lnclient/phoenixd/phoenixd.go
@@ -487,3 +487,11 @@ func (svc *PhoenixService) DisconnectPeer(ctx context.Context, peerId string) er
 func (svc *PhoenixService) UpdateChannel(ctx context.Context, updateChannelRequest *lnclient.UpdateChannelRequest) error {
 	return nil
 }
+
+func (svc *PhoenixService) GetSupportedNIP47Capabilities() string {
+	return "pay_invoice get_balance get_info make_invoice lookup_invoice list_transactions multi_pay_invoice"
+}
+
+func (svc *PhoenixService) GetSupportedNIP47NotificationTypes() string {
+	return ""
+}

--- a/nip47/controllers/get_info_controller.go
+++ b/nip47/controllers/get_info_controller.go
@@ -48,7 +48,7 @@ func (controller *getInfoController) HandleGetInfoEvent(ctx context.Context, nip
 	}
 
 	// basic permissions check
-	hasPermission, _, _ := controller.permissionsService.HasPermission(app, nip47Request.Method, 0)
+	hasPermission, _, _ := controller.permissionsService.HasPermission(app, permissions.GET_INFO_SCOPE, 0)
 	if hasPermission {
 		logger.Logger.WithFields(logrus.Fields{
 			"request_event_id": requestEventId,

--- a/nip47/controllers/get_info_controller.go
+++ b/nip47/controllers/get_info_controller.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"context"
-	"strings"
 
 	"github.com/getAlby/nostr-wallet-connect/db"
 	"github.com/getAlby/nostr-wallet-connect/lnclient"
@@ -39,7 +38,7 @@ func NewGetInfoController(permissionsService permissions.PermissionsService, lnC
 func (controller *getInfoController) HandleGetInfoEvent(ctx context.Context, nip47Request *models.Request, requestEventId uint, app *db.App, checkPermission checkPermissionFunc, publishResponse publishFunc) {
 	supportedNotifications := []string{}
 	if controller.permissionsService.PermitsNotifications(app) {
-		supportedNotifications = strings.Split(controller.lnClient.GetSupportedNIP47NotificationTypes(), " ")
+		supportedNotifications = controller.lnClient.GetSupportedNIP47NotificationTypes()
 	}
 
 	responsePayload := &getInfoResponse{

--- a/nip47/controllers/get_info_controller.go
+++ b/nip47/controllers/get_info_controller.go
@@ -8,7 +8,6 @@ import (
 	"github.com/getAlby/nostr-wallet-connect/lnclient"
 	"github.com/getAlby/nostr-wallet-connect/logger"
 	"github.com/getAlby/nostr-wallet-connect/nip47/models"
-	"github.com/getAlby/nostr-wallet-connect/nip47/notifications"
 	permissions "github.com/getAlby/nostr-wallet-connect/nip47/permissions"
 	"github.com/nbd-wtf/go-nostr"
 	"github.com/sirupsen/logrus"
@@ -40,12 +39,11 @@ func NewGetInfoController(permissionsService permissions.PermissionsService, lnC
 func (controller *getInfoController) HandleGetInfoEvent(ctx context.Context, nip47Request *models.Request, requestEventId uint, app *db.App, checkPermission checkPermissionFunc, publishResponse publishFunc) {
 	supportedNotifications := []string{}
 	if controller.permissionsService.PermitsNotifications(app) {
-		// TODO: this needs to be LNClient-specific
-		supportedNotifications = strings.Split(notifications.NOTIFICATION_TYPES, " ")
+		supportedNotifications = strings.Split(controller.lnClient.GetSupportedNIP47NotificationTypes(), " ")
 	}
 
 	responsePayload := &getInfoResponse{
-		Methods:       controller.permissionsService.GetPermittedMethods(app),
+		Methods:       controller.permissionsService.GetPermittedMethods(app, controller.lnClient),
 		Notifications: supportedNotifications,
 	}
 

--- a/nip47/controllers/get_info_controller_test.go
+++ b/nip47/controllers/get_info_controller_test.go
@@ -40,7 +40,7 @@ func TestHandleGetInfoEvent_NoPermission(t *testing.T) {
 
 	appPermission := &db.AppPermission{
 		AppId:     app.ID,
-		Scope:     models.GET_BALANCE_METHOD,
+		Scope:     permissions.GET_BALANCE_SCOPE,
 		ExpiresAt: nil,
 	}
 	err = svc.DB.Create(appPermission).Error
@@ -97,7 +97,7 @@ func TestHandleGetInfoEvent_WithPermission(t *testing.T) {
 
 	appPermission := &db.AppPermission{
 		AppId:     app.ID,
-		Scope:     models.GET_INFO_METHOD,
+		Scope:     permissions.GET_INFO_SCOPE,
 		ExpiresAt: nil,
 	}
 	err = svc.DB.Create(appPermission).Error
@@ -149,7 +149,7 @@ func TestHandleGetInfoEvent_WithNotifications(t *testing.T) {
 
 	appPermission := &db.AppPermission{
 		AppId:     app.ID,
-		Scope:     models.GET_INFO_METHOD,
+		Scope:     permissions.GET_INFO_SCOPE,
 		ExpiresAt: nil,
 	}
 	err = svc.DB.Create(appPermission).Error
@@ -158,7 +158,7 @@ func TestHandleGetInfoEvent_WithNotifications(t *testing.T) {
 	// TODO: AppPermission RequestMethod needs to change to scope
 	appPermission = &db.AppPermission{
 		AppId:     app.ID,
-		Scope:     "notifications",
+		Scope:     permissions.NOTIFICATIONS_SCOPE,
 		ExpiresAt: nil,
 	}
 	err = svc.DB.Create(appPermission).Error

--- a/nip47/controllers/get_info_controller_test.go
+++ b/nip47/controllers/get_info_controller_test.go
@@ -39,9 +39,9 @@ func TestHandleGetInfoEvent_NoPermission(t *testing.T) {
 	assert.NoError(t, err)
 
 	appPermission := &db.AppPermission{
-		AppId:         app.ID,
-		RequestMethod: models.GET_BALANCE_METHOD,
-		ExpiresAt:     nil,
+		AppId:     app.ID,
+		Scope:     models.GET_BALANCE_METHOD,
+		ExpiresAt: nil,
 	}
 	err = svc.DB.Create(appPermission).Error
 	assert.NoError(t, err)
@@ -96,9 +96,9 @@ func TestHandleGetInfoEvent_WithPermission(t *testing.T) {
 	assert.NoError(t, err)
 
 	appPermission := &db.AppPermission{
-		AppId:         app.ID,
-		RequestMethod: models.GET_INFO_METHOD,
-		ExpiresAt:     nil,
+		AppId:     app.ID,
+		Scope:     models.GET_INFO_METHOD,
+		ExpiresAt: nil,
 	}
 	err = svc.DB.Create(appPermission).Error
 	assert.NoError(t, err)
@@ -148,18 +148,18 @@ func TestHandleGetInfoEvent_WithNotifications(t *testing.T) {
 	assert.NoError(t, err)
 
 	appPermission := &db.AppPermission{
-		AppId:         app.ID,
-		RequestMethod: models.GET_INFO_METHOD,
-		ExpiresAt:     nil,
+		AppId:     app.ID,
+		Scope:     models.GET_INFO_METHOD,
+		ExpiresAt: nil,
 	}
 	err = svc.DB.Create(appPermission).Error
 	assert.NoError(t, err)
 
 	// TODO: AppPermission RequestMethod needs to change to scope
 	appPermission = &db.AppPermission{
-		AppId:         app.ID,
-		RequestMethod: "notifications",
-		ExpiresAt:     nil,
+		AppId:     app.ID,
+		Scope:     "notifications",
+		ExpiresAt: nil,
 	}
 	err = svc.DB.Create(appPermission).Error
 	assert.NoError(t, err)

--- a/nip47/event_handler.go
+++ b/nip47/event_handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/getAlby/nostr-wallet-connect/logger"
 	controllers "github.com/getAlby/nostr-wallet-connect/nip47/controllers"
 	"github.com/getAlby/nostr-wallet-connect/nip47/models"
+	"github.com/getAlby/nostr-wallet-connect/nip47/permissions"
 	"github.com/nbd-wtf/go-nostr"
 	"github.com/nbd-wtf/go-nostr/nip04"
 	"github.com/sirupsen/logrus"
@@ -240,7 +241,17 @@ func (svc *nip47Service) HandleEvent(ctx context.Context, sub *nostr.Subscriptio
 	}
 
 	checkPermission := func(amountMsat uint64) *models.Response {
-		hasPermission, code, message := svc.permissionsService.HasPermission(&app, nip47Request.Method, amountMsat)
+		scope, err := permissions.RequestMethodToScope(nip47Request.Method)
+		if err != nil {
+			return &models.Response{
+				ResultType: nip47Request.Method,
+				Error: &models.Error{
+					Code:    models.ERROR_INTERNAL,
+					Message: err.Error(),
+				},
+			}
+		}
+		hasPermission, code, message := svc.permissionsService.HasPermission(&app, scope, amountMsat)
 		if !hasPermission {
 			logger.Logger.WithFields(logrus.Fields{
 				"request_event_id": requestEvent.ID,

--- a/nip47/models/models.go
+++ b/nip47/models/models.go
@@ -30,7 +30,6 @@ const (
 	ERROR_RESTRICTED           = "RESTRICTED"
 	ERROR_BAD_REQUEST          = "BAD_REQUEST"
 	OTHER                      = "OTHER"
-	CAPABILITIES               = "pay_invoice pay_keysend get_balance get_info make_invoice lookup_invoice list_transactions multi_pay_invoice multi_pay_keysend sign_message notifications"
 )
 
 const (

--- a/nip47/models/models.go
+++ b/nip47/models/models.go
@@ -7,20 +7,23 @@ import (
 )
 
 const (
-	INFO_EVENT_KIND            = 13194
-	REQUEST_KIND               = 23194
-	RESPONSE_KIND              = 23195
-	NOTIFICATION_KIND          = 23196
-	PAY_INVOICE_METHOD         = "pay_invoice"
-	GET_BALANCE_METHOD         = "get_balance"
-	GET_INFO_METHOD            = "get_info"
-	MAKE_INVOICE_METHOD        = "make_invoice"
-	LOOKUP_INVOICE_METHOD      = "lookup_invoice"
-	LIST_TRANSACTIONS_METHOD   = "list_transactions"
-	PAY_KEYSEND_METHOD         = "pay_keysend"
-	MULTI_PAY_INVOICE_METHOD   = "multi_pay_invoice"
-	MULTI_PAY_KEYSEND_METHOD   = "multi_pay_keysend"
-	SIGN_MESSAGE_METHOD        = "sign_message"
+	INFO_EVENT_KIND   = 13194
+	REQUEST_KIND      = 23194
+	RESPONSE_KIND     = 23195
+	NOTIFICATION_KIND = 23196
+
+	// request methods
+	PAY_INVOICE_METHOD       = "pay_invoice"
+	GET_BALANCE_METHOD       = "get_balance"
+	GET_INFO_METHOD          = "get_info"
+	MAKE_INVOICE_METHOD      = "make_invoice"
+	LOOKUP_INVOICE_METHOD    = "lookup_invoice"
+	LIST_TRANSACTIONS_METHOD = "list_transactions"
+	PAY_KEYSEND_METHOD       = "pay_keysend"
+	MULTI_PAY_INVOICE_METHOD = "multi_pay_invoice"
+	MULTI_PAY_KEYSEND_METHOD = "multi_pay_keysend"
+	SIGN_MESSAGE_METHOD      = "sign_message"
+
 	ERROR_INTERNAL             = "INTERNAL"
 	ERROR_NOT_IMPLEMENTED      = "NOT_IMPLEMENTED"
 	ERROR_QUOTA_EXCEEDED       = "QUOTA_EXCEEDED"

--- a/nip47/nip47_service.go
+++ b/nip47/nip47_service.go
@@ -25,7 +25,7 @@ type nip47Service struct {
 type Nip47Service interface {
 	StartNotifier(ctx context.Context, relay *nostr.Relay, lnClient lnclient.LNClient)
 	HandleEvent(ctx context.Context, sub *nostr.Subscription, event *nostr.Event, lnClient lnclient.LNClient)
-	PublishNip47Info(ctx context.Context, relay *nostr.Relay) error
+	PublishNip47Info(ctx context.Context, relay *nostr.Relay, lnClient lnclient.LNClient) error
 	CreateResponse(initialEvent *nostr.Event, content interface{}, tags nostr.Tags, ss []byte) (result *nostr.Event, err error)
 }
 

--- a/nip47/notifications/models.go
+++ b/nip47/notifications/models.go
@@ -8,7 +8,6 @@ type Notification struct {
 }
 
 const (
-	NOTIFICATION_TYPES            = "payment_received payment_sent"
 	PAYMENT_RECEIVED_NOTIFICATION = "payment_received"
 	PAYMENT_SENT_NOTIFICATION     = "payment_sent"
 )

--- a/nip47/notifications/nip47_notifier.go
+++ b/nip47/notifications/nip47_notifier.go
@@ -104,7 +104,7 @@ func (notifier *Nip47Notifier) notifySubscribers(ctx context.Context, notificati
 	notifier.db.Find(&apps)
 
 	for _, app := range apps {
-		hasPermission, _, _ := notifier.permissionsSvc.HasPermission(&app, permissions.NOTIFICATIONS_PERMISSION, 0)
+		hasPermission, _, _ := notifier.permissionsSvc.HasPermission(&app, permissions.NOTIFICATIONS_SCOPE, 0)
 		if !hasPermission {
 			continue
 		}

--- a/nip47/notifications/nip47_notifier_test.go
+++ b/nip47/notifications/nip47_notifier_test.go
@@ -25,9 +25,9 @@ func TestSendNotification_PaymentReceived(t *testing.T) {
 	assert.NoError(t, err)
 
 	appPermission := &db.AppPermission{
-		AppId:         app.ID,
-		App:           *app,
-		RequestMethod: permissions.NOTIFICATIONS_PERMISSION,
+		AppId: app.ID,
+		App:   *app,
+		Scope: permissions.NOTIFICATIONS_SCOPE,
 	}
 	err = svc.DB.Create(appPermission).Error
 	assert.NoError(t, err)
@@ -89,9 +89,9 @@ func TestSendNotification_PaymentSent(t *testing.T) {
 	assert.NoError(t, err)
 
 	appPermission := &db.AppPermission{
-		AppId:         app.ID,
-		App:           *app,
-		RequestMethod: permissions.NOTIFICATIONS_PERMISSION,
+		AppId: app.ID,
+		App:   *app,
+		Scope: permissions.NOTIFICATIONS_SCOPE,
 	}
 	err = svc.DB.Create(appPermission).Error
 	assert.NoError(t, err)

--- a/nip47/permissions/permissions.go
+++ b/nip47/permissions/permissions.go
@@ -186,7 +186,9 @@ func RequestMethodsToScopes(requestMethods []string) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		scopes = append(scopes, scope)
+		if !slices.Contains(scopes, scope) {
+			scopes = append(scopes, scope)
+		}
 	}
 	return scopes, nil
 }

--- a/nip47/permissions/permissions.go
+++ b/nip47/permissions/permissions.go
@@ -105,7 +105,7 @@ func (svc *permissionsService) GetPermittedMethods(app *db.App, lnClient lnclien
 	}
 
 	// only return methods supported by the lnClient
-	lnClientSupportedMethods := strings.Split(lnClient.GetSupportedNIP47Capabilities(), " ")
+	lnClientSupportedMethods := strings.Split(lnClient.GetSupportedNIP47Methods(), " ")
 	requestMethods = utils.Filter(requestMethods, func(requestMethod string) bool {
 		return slices.Contains(lnClientSupportedMethods, requestMethod)
 	})

--- a/nip47/permissions/permissions.go
+++ b/nip47/permissions/permissions.go
@@ -115,7 +115,7 @@ func (svc *permissionsService) PermitsNotifications(app *db.App) bool {
 	notificationPermission := db.AppPermission{}
 	err := svc.db.First(&notificationPermission, &db.AppPermission{
 		AppId: app.ID,
-		Scope: "notifications",
+		Scope: NOTIFICATIONS_SCOPE,
 	}).Error
 	if err != nil {
 		return false

--- a/nip47/permissions/permissions.go
+++ b/nip47/permissions/permissions.go
@@ -180,7 +180,7 @@ func scopeToRequestMethods(scope string) []string {
 func RequestMethodsToScopes(requestMethods []string) ([]string, error) {
 	scopes := []string{}
 
-	for _, requestMethod := range scopes {
+	for _, requestMethod := range requestMethods {
 		scope, err := RequestMethodToScope(requestMethod)
 		if err != nil {
 			return nil, err

--- a/nip47/permissions/permissions.go
+++ b/nip47/permissions/permissions.go
@@ -178,6 +178,19 @@ func scopeToRequestMethods(scope string) []string {
 	return []string{}
 }
 
+func RequestMethodsToScopes(requestMethods []string) ([]string, error) {
+	scopes := []string{}
+
+	for _, requestMethod := range scopes {
+		scope, err := RequestMethodToScope(requestMethod)
+		if err != nil {
+			return nil, err
+		}
+		scopes = append(scopes, scope)
+	}
+	return scopes, nil
+}
+
 func RequestMethodToScope(requestMethod string) (string, error) {
 	switch requestMethod {
 	case models.PAY_INVOICE_METHOD, models.PAY_KEYSEND_METHOD, models.MULTI_PAY_INVOICE_METHOD, models.MULTI_PAY_KEYSEND_METHOD:

--- a/nip47/permissions/permissions.go
+++ b/nip47/permissions/permissions.go
@@ -212,3 +212,16 @@ func RequestMethodToScope(requestMethod string) (string, error) {
 	logger.Logger.WithField("request_method", requestMethod).Error("Unsupported request method")
 	return "", fmt.Errorf("unsupported request method: %s", requestMethod)
 }
+
+func AllScopes() []string {
+	return []string{
+		PAY_INVOICE_SCOPE,
+		GET_BALANCE_SCOPE,
+		GET_INFO_SCOPE,
+		MAKE_INVOICE_SCOPE,
+		LOOKUP_INVOICE_SCOPE,
+		LIST_TRANSACTIONS_SCOPE,
+		SIGN_MESSAGE_SCOPE,
+		NOTIFICATIONS_SCOPE,
+	}
+}

--- a/nip47/permissions/permissions.go
+++ b/nip47/permissions/permissions.go
@@ -56,7 +56,7 @@ func (svc *permissionsService) HasPermission(app *db.App, scope string, amountMs
 	})
 	if findPermissionResult.RowsAffected == 0 {
 		// No permission for this request method
-		return false, models.ERROR_RESTRICTED, fmt.Sprintf("This app does not have permission to request %s", scope)
+		return false, models.ERROR_RESTRICTED, fmt.Sprintf("This app does not have the %s scope", scope)
 	}
 	expiresAt := appPermission.ExpiresAt
 	if expiresAt != nil && expiresAt.Before(time.Now()) {

--- a/nip47/permissions/permissions.go
+++ b/nip47/permissions/permissions.go
@@ -3,7 +3,6 @@ package permissions
 import (
 	"fmt"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/getAlby/nostr-wallet-connect/db"
@@ -103,7 +102,7 @@ func (svc *permissionsService) GetPermittedMethods(app *db.App, lnClient lnclien
 	requestMethods := scopesToRequestMethods(scopes)
 
 	// only return methods supported by the lnClient
-	lnClientSupportedMethods := strings.Split(lnClient.GetSupportedNIP47Methods(), " ")
+	lnClientSupportedMethods := lnClient.GetSupportedNIP47Methods()
 	requestMethods = utils.Filter(requestMethods, func(requestMethod string) bool {
 		return slices.Contains(lnClientSupportedMethods, requestMethod)
 	})

--- a/nip47/permissions/permissions_test.go
+++ b/nip47/permissions/permissions_test.go
@@ -22,7 +22,7 @@ func TestHasPermission_NoPermission(t *testing.T) {
 	result, code, message := permissionsSvc.HasPermission(app, PAY_INVOICE_SCOPE, 100)
 	assert.False(t, result)
 	assert.Equal(t, models.ERROR_RESTRICTED, code)
-	assert.Equal(t, "This app does not have permission to request pay_invoice", message)
+	assert.Equal(t, "This app does not have the pay_invoice scope", message)
 }
 
 func TestHasPermission_Expired(t *testing.T) {

--- a/nip47/permissions/permissions_test.go
+++ b/nip47/permissions/permissions_test.go
@@ -19,7 +19,7 @@ func TestHasPermission_NoPermission(t *testing.T) {
 	assert.NoError(t, err)
 
 	permissionsSvc := NewPermissionsService(svc.DB, svc.EventPublisher)
-	result, code, message := permissionsSvc.HasPermission(app, models.PAY_INVOICE_METHOD, 100)
+	result, code, message := permissionsSvc.HasPermission(app, PAY_INVOICE_SCOPE, 100)
 	assert.False(t, result)
 	assert.Equal(t, models.ERROR_RESTRICTED, code)
 	assert.Equal(t, "This app does not have permission to request pay_invoice", message)
@@ -38,7 +38,7 @@ func TestHasPermission_Expired(t *testing.T) {
 	appPermission := &db.AppPermission{
 		AppId:         app.ID,
 		App:           *app,
-		RequestMethod: models.PAY_INVOICE_METHOD,
+		Scope:         PAY_INVOICE_SCOPE,
 		MaxAmount:     100,
 		BudgetRenewal: budgetRenewal,
 		ExpiresAt:     &expiresAt,
@@ -47,7 +47,7 @@ func TestHasPermission_Expired(t *testing.T) {
 	assert.NoError(t, err)
 
 	permissionsSvc := NewPermissionsService(svc.DB, svc.EventPublisher)
-	result, code, message := permissionsSvc.HasPermission(app, models.PAY_INVOICE_METHOD, 100)
+	result, code, message := permissionsSvc.HasPermission(app, PAY_INVOICE_SCOPE, 100)
 	assert.False(t, result)
 	assert.Equal(t, models.ERROR_EXPIRED, code)
 	assert.Equal(t, "This app has expired", message)
@@ -66,7 +66,7 @@ func TestHasPermission_Exceeded(t *testing.T) {
 	appPermission := &db.AppPermission{
 		AppId:         app.ID,
 		App:           *app,
-		RequestMethod: models.PAY_INVOICE_METHOD,
+		Scope:         models.PAY_INVOICE_METHOD,
 		MaxAmount:     10,
 		BudgetRenewal: budgetRenewal,
 		ExpiresAt:     &expiresAt,
@@ -75,7 +75,7 @@ func TestHasPermission_Exceeded(t *testing.T) {
 	assert.NoError(t, err)
 
 	permissionsSvc := NewPermissionsService(svc.DB, svc.EventPublisher)
-	result, code, message := permissionsSvc.HasPermission(app, models.PAY_INVOICE_METHOD, 100*1000)
+	result, code, message := permissionsSvc.HasPermission(app, PAY_INVOICE_SCOPE, 100*1000)
 	assert.False(t, result)
 	assert.Equal(t, models.ERROR_QUOTA_EXCEEDED, code)
 	assert.Equal(t, "Insufficient budget remaining to make payment", message)
@@ -94,7 +94,7 @@ func TestHasPermission_OK(t *testing.T) {
 	appPermission := &db.AppPermission{
 		AppId:         app.ID,
 		App:           *app,
-		RequestMethod: models.PAY_INVOICE_METHOD,
+		Scope:         models.PAY_INVOICE_METHOD,
 		MaxAmount:     10,
 		BudgetRenewal: budgetRenewal,
 		ExpiresAt:     &expiresAt,

--- a/nip47/publish_nip47_info.go
+++ b/nip47/publish_nip47_info.go
@@ -3,18 +3,16 @@ package nip47
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/getAlby/nostr-wallet-connect/lnclient"
 	"github.com/getAlby/nostr-wallet-connect/nip47/models"
-	"github.com/getAlby/nostr-wallet-connect/utils"
 	"github.com/nbd-wtf/go-nostr"
 )
 
 func (svc *nip47Service) PublishNip47Info(ctx context.Context, relay *nostr.Relay, lnClient lnclient.LNClient) error {
 	ev := &nostr.Event{}
 	ev.Kind = models.INFO_EVENT_KIND
-	ev.Content = strings.Join(nip47CapabilitiesToMethods(strings.Split(lnClient.GetSupportedNIP47Capabilities(), " ")), " ")
+	ev.Content = lnClient.GetSupportedNIP47Methods()
 	ev.CreatedAt = nostr.Now()
 	ev.PubKey = svc.keys.GetNostrPublicKey()
 	ev.Tags = nostr.Tags{[]string{"notifications", lnClient.GetSupportedNIP47NotificationTypes()}}
@@ -27,10 +25,4 @@ func (svc *nip47Service) PublishNip47Info(ctx context.Context, relay *nostr.Rela
 		return fmt.Errorf("nostr publish not successful: %s", err)
 	}
 	return nil
-}
-
-func nip47CapabilitiesToMethods(capabilities []string) []string {
-	return utils.Filter(capabilities, func(s string) bool {
-		return s != "notifications"
-	})
 }

--- a/nip47/publish_nip47_info.go
+++ b/nip47/publish_nip47_info.go
@@ -3,6 +3,7 @@ package nip47
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/getAlby/nostr-wallet-connect/lnclient"
 	"github.com/getAlby/nostr-wallet-connect/nip47/models"
@@ -12,10 +13,10 @@ import (
 func (svc *nip47Service) PublishNip47Info(ctx context.Context, relay *nostr.Relay, lnClient lnclient.LNClient) error {
 	ev := &nostr.Event{}
 	ev.Kind = models.INFO_EVENT_KIND
-	ev.Content = lnClient.GetSupportedNIP47Methods()
+	ev.Content = strings.Join(lnClient.GetSupportedNIP47Methods(), " ")
 	ev.CreatedAt = nostr.Now()
 	ev.PubKey = svc.keys.GetNostrPublicKey()
-	ev.Tags = nostr.Tags{[]string{"notifications", lnClient.GetSupportedNIP47NotificationTypes()}}
+	ev.Tags = nostr.Tags{[]string{"notifications", strings.Join(lnClient.GetSupportedNIP47NotificationTypes(), " ")}}
 	err := ev.Sign(svc.keys.GetNostrSecretKey())
 	if err != nil {
 		return err

--- a/nip47/publish_nip47_info.go
+++ b/nip47/publish_nip47_info.go
@@ -11,9 +11,14 @@ import (
 )
 
 func (svc *nip47Service) PublishNip47Info(ctx context.Context, relay *nostr.Relay, lnClient lnclient.LNClient) error {
+	capabilities := lnClient.GetSupportedNIP47Methods()
+	if len(lnClient.GetSupportedNIP47NotificationTypes()) > 0 {
+		capabilities = append(capabilities, "notifications")
+	}
+
 	ev := &nostr.Event{}
 	ev.Kind = models.INFO_EVENT_KIND
-	ev.Content = strings.Join(lnClient.GetSupportedNIP47Methods(), " ")
+	ev.Content = strings.Join(capabilities, " ")
 	ev.CreatedAt = nostr.Now()
 	ev.PubKey = svc.keys.GetNostrPublicKey()
 	ev.Tags = nostr.Tags{[]string{"notifications", strings.Join(lnClient.GetSupportedNIP47NotificationTypes(), " ")}}

--- a/nip47/publish_nip47_info.go
+++ b/nip47/publish_nip47_info.go
@@ -3,19 +3,21 @@ package nip47
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/getAlby/nostr-wallet-connect/lnclient"
 	"github.com/getAlby/nostr-wallet-connect/nip47/models"
-	"github.com/getAlby/nostr-wallet-connect/nip47/notifications"
+	"github.com/getAlby/nostr-wallet-connect/utils"
 	"github.com/nbd-wtf/go-nostr"
 )
 
-func (svc *nip47Service) PublishNip47Info(ctx context.Context, relay *nostr.Relay) error {
+func (svc *nip47Service) PublishNip47Info(ctx context.Context, relay *nostr.Relay, lnClient lnclient.LNClient) error {
 	ev := &nostr.Event{}
 	ev.Kind = models.INFO_EVENT_KIND
-	ev.Content = models.CAPABILITIES
+	ev.Content = strings.Join(nip47CapabilitiesToMethods(strings.Split(lnClient.GetSupportedNIP47Capabilities(), " ")), " ")
 	ev.CreatedAt = nostr.Now()
 	ev.PubKey = svc.keys.GetNostrPublicKey()
-	ev.Tags = nostr.Tags{[]string{"notifications", notifications.NOTIFICATION_TYPES}}
+	ev.Tags = nostr.Tags{[]string{"notifications", lnClient.GetSupportedNIP47NotificationTypes()}}
 	err := ev.Sign(svc.keys.GetNostrSecretKey())
 	if err != nil {
 		return err
@@ -25,4 +27,10 @@ func (svc *nip47Service) PublishNip47Info(ctx context.Context, relay *nostr.Rela
 		return fmt.Errorf("nostr publish not successful: %s", err)
 	}
 	return nil
+}
+
+func nip47CapabilitiesToMethods(capabilities []string) []string {
+	return utils.Filter(capabilities, func(s string) bool {
+		return s != "notifications"
+	})
 }

--- a/service/start.go
+++ b/service/start.go
@@ -74,7 +74,7 @@ func (svc *service) StartNostr(ctx context.Context, encryptionKey string) error 
 			}
 
 			//publish event with NIP-47 info
-			err = svc.nip47Service.PublishNip47Info(ctx, relay)
+			err = svc.nip47Service.PublishNip47Info(ctx, relay, svc.lnClient)
 			if err != nil {
 				logger.Logger.WithError(err).Error("Could not publish NIP47 info")
 			}

--- a/tests/mock_ln_client.go
+++ b/tests/mock_ln_client.go
@@ -162,8 +162,8 @@ func (mln *MockLn) UpdateChannel(ctx context.Context, updateChannelRequest *lncl
 }
 
 func (mln *MockLn) GetSupportedNIP47Capabilities() string {
-	return ""
+	return "pay_invoice pay_keysend get_balance get_info make_invoice lookup_invoice list_transactions multi_pay_invoice multi_pay_keysend sign_message notifications"
 }
 func (mln *MockLn) GetSupportedNIP47NotificationTypes() string {
-	return ""
+	return "payment_received payment_sent"
 }

--- a/tests/mock_ln_client.go
+++ b/tests/mock_ln_client.go
@@ -161,8 +161,8 @@ func (mln *MockLn) UpdateChannel(ctx context.Context, updateChannelRequest *lncl
 	return nil
 }
 
-func (mln *MockLn) GetSupportedNIP47Capabilities() string {
-	return "pay_invoice pay_keysend get_balance get_info make_invoice lookup_invoice list_transactions multi_pay_invoice multi_pay_keysend sign_message notifications"
+func (mln *MockLn) GetSupportedNIP47Methods() string {
+	return "pay_invoice pay_keysend get_balance get_info make_invoice lookup_invoice list_transactions multi_pay_invoice multi_pay_keysend sign_message"
 }
 func (mln *MockLn) GetSupportedNIP47NotificationTypes() string {
 	return "payment_received payment_sent"

--- a/tests/mock_ln_client.go
+++ b/tests/mock_ln_client.go
@@ -161,9 +161,9 @@ func (mln *MockLn) UpdateChannel(ctx context.Context, updateChannelRequest *lncl
 	return nil
 }
 
-func (mln *MockLn) GetSupportedNIP47Methods() string {
-	return "pay_invoice pay_keysend get_balance get_info make_invoice lookup_invoice list_transactions multi_pay_invoice multi_pay_keysend sign_message"
+func (mln *MockLn) GetSupportedNIP47Methods() []string {
+	return []string{"pay_invoice", "pay_keysend", "get_balance", "get_info", "make_invoice", "lookup_invoice", "list_transactions", "multi_pay_invoice", "multi_pay_keysend", "sign_message"}
 }
-func (mln *MockLn) GetSupportedNIP47NotificationTypes() string {
-	return "payment_received payment_sent"
+func (mln *MockLn) GetSupportedNIP47NotificationTypes() []string {
+	return []string{"payment_received", "payment_sent"}
 }

--- a/tests/mock_ln_client.go
+++ b/tests/mock_ln_client.go
@@ -160,3 +160,10 @@ func (mln *MockLn) DisconnectPeer(ctx context.Context, peerId string) error {
 func (mln *MockLn) UpdateChannel(ctx context.Context, updateChannelRequest *lnclient.UpdateChannelRequest) error {
 	return nil
 }
+
+func (mln *MockLn) GetSupportedNIP47Capabilities() string {
+	return ""
+}
+func (mln *MockLn) GetSupportedNIP47NotificationTypes() string {
+	return ""
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -44,3 +44,14 @@ func ReadFileTail(filePath string, maxLen int) (data []byte, err error) {
 
 	return data, nil
 }
+
+// filters values from a slice
+func Filter[T any](s []T, f func(T) bool) []T {
+	var r []T
+	for _, v := range s {
+		if f(v) {
+			r = append(r, v)
+		}
+	}
+	return r
+}

--- a/wails/wails_handlers.go
+++ b/wails/wails_handlers.go
@@ -338,7 +338,6 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 		}
 		return WailsRequestRouterResponse{Body: newAddress, Error: ""}
 	case "/api/wallet/redeem-onchain-funds":
-
 		redeemOnchainFundsRequest := &api.RedeemOnchainFundsRequest{}
 		err := json.Unmarshal([]byte(body), redeemOnchainFundsRequest)
 		if err != nil {
@@ -363,6 +362,12 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 		}
 		return WailsRequestRouterResponse{Body: *signMessageResponse, Error: ""}
+	case "/api/wallet/capabilities":
+		capabilitiesResponse, err := app.api.GetWalletCapabilities(ctx)
+		if err != nil {
+			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
+		}
+		return WailsRequestRouterResponse{Body: *capabilitiesResponse, Error: ""}
 	// TODO: review naming
 	case "/api/instant-channel-invoices":
 		newInstantChannelRequest := &api.NewInstantChannelInvoiceRequest{}
@@ -418,7 +423,7 @@ func (app *WailsApp) WailsRequestRouter(route string, method string, body string
 		res := WailsRequestRouterResponse{Body: *infoResponse, Error: ""}
 		return res
 	case "/api/alby/link-account":
-		err := app.svc.GetAlbyOAuthSvc().LinkAccount(ctx)
+		err := app.svc.GetAlbyOAuthSvc().LinkAccount(ctx, app.svc.GetLNClient())
 		if err != nil {
 			return WailsRequestRouterResponse{Body: nil, Error: err.Error()}
 		}


### PR DESCRIPTION
Fixes https://github.com/getAlby/nostr-wallet-connect-next/issues/219
Fixes https://github.com/getAlby/nostr-wallet-connect-next/issues/353

This PR allows individual LNClients to set what capabilities and notification types they support. On the frontend when creating a new app, you'll only be shown capabilities that your LNClient supports.

## TODOs
- [x] fix tests
- [x] renaming
- [x] DB migration
- [x] code/architecture review
  - [x] naming around permissions, capabilities, methods and notifications
  - [x] how request methods are mapped to scopes and back
- Manual Testing
  - [x] create app via query params
    - [x] unsupported request methods
    - [x] unsupported notification types
  - [x] defaults scopes for different lnclients
  - [x] view app page
  - [x] update app
  - [x] app store
  - [x] check get_info and wallet service info nostr event content
- [x] ~~review and merge https://github.com/getAlby/js-sdk/pull/227~~
  
## TERMS
**Permission** a scope for an app, including budgeting and expiry info. It is the name of a **table**
**Scope** `pay_invoice` covers all payment methods. `make_invoice` covers only making invoices. `notifications` covers all notification types.
**Request Method** `pay_invoice`, `pay_keysend`
**Notification Type** `payment_sent` or `payment_received`

- Apps do NOT know about their capabilties (request methods and notifications), only scopes.

## REFACTORING
In our DB we save a `scope` as a `request_method` which has turned into a giant mess throughout the codebase. This PR attempts to fix this by doing the minimal change to rename the column to `scope` and any necessary variables in the code.

This PR does not reduce the number of scopes as there were previous ideas about, and we will probably not do this in the future - only simplify the frontend.