### PR TITLE
fix: increase yarn timeout in Docker image to fix failing arm64 builds

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -9,10 +9,10 @@ jobs:
       TAG: ${{ github.ref_name }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         name: Check out code
       - name: Install Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v5
         with:
           go-version: 1.21.x
       - name: Checkout code

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -15,8 +15,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.21.x
-      - name: Checkout code
-        uses: actions/checkout@v2
       - name: Run tests
         run: mkdir frontend/dist && touch frontend/dist/tmp && go test ./...
       - name: Docker build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20-alpine as frontend
 WORKDIR /build
 COPY frontend ./frontend
-RUN cd frontend && yarn install && yarn build:http
+RUN cd frontend && yarn install --network-timeout 3000000 && yarn build:http
 
 FROM golang:1.22.2 as builder
 


### PR DESCRIPTION
This seems to be a known issue people experience often: https://github.com/nodejs/docker-node/issues/1335