### PR TITLE
feat: add extra info to the channel opening page

### DIFF
--- a/frontend/src/screens/channels/CurrentChannelOrder.tsx
+++ b/frontend/src/screens/channels/CurrentChannelOrder.tsx
@@ -142,6 +142,10 @@ function ChannelOpening({ fundingTxId }: { fundingTxId: string | undefined }) {
           </div>
         </CardContent>
       </Card>
+      <div className="w-full mt-40 gap-20 flex flex-col items-center justify-center">
+        <p>Feel free to leave this page or browse around Alby Hub!</p>
+        <p>We'll send you an email as soon as your channel is active.</p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Our new design (which we haven't implemented yet) also does not cover this useful info.

I need help with the design (It will take time to implement the new channel opening design)

![image](https://github.com/getAlby/nostr-wallet-connect-next/assets/33993199/506a798f-85db-44c5-8f68-0bcc55c5bd1a)

