### PR TITLE
feat: channel liquidity alerts on liquidity page

### DIFF
--- a/frontend/src/components/SidebarHint.tsx
+++ b/frontend/src/components/SidebarHint.tsx
@@ -27,8 +27,7 @@ function SidebarHint() {
 
   // Don't distract with hints while opening a channel or on the settings page
   if (
-    location.pathname.endsWith("/channels/order") ||
-    location.pathname.endsWith("/channels") ||
+    location.pathname.startsWith("/channels/") ||
     location.pathname.startsWith("/settings")
   ) {
     return null;

--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -1,4 +1,5 @@
 import {
+  AlertTriangle,
   ArrowDown,
   ArrowUp,
   Bitcoin,
@@ -18,6 +19,11 @@ import AppHeader from "src/components/AppHeader.tsx";
 import EmptyState from "src/components/EmptyState.tsx";
 import ExternalLink from "src/components/ExternalLink";
 import Loading from "src/components/Loading.tsx";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "src/components/ui/alert.tsx";
 import { Badge } from "src/components/ui/badge.tsx";
 import { Button } from "src/components/ui/button.tsx";
 import {
@@ -361,6 +367,52 @@ export default function Channels() {
         }
       ></AppHeader>
 
+      {!!channels?.length && (
+        <>
+          {/* If all channels have less than 20% incoming capacity, show a warning */}
+          {channels?.every(
+            (channel) =>
+              channel.remoteBalance <
+              (channel.localBalance + channel.remoteBalance) * 0.2
+          ) && (
+            <Alert>
+              <AlertTriangle className="h-4 w-4" />
+              <AlertTitle>Low receiving capacity</AlertTitle>
+              <AlertDescription>
+                You likely won't be able to receive payments until you{" "}
+                <ExternalLink
+                  className="underline"
+                  to="https://guides.getalby.com/user-guide/v/alby-account-and-browser-extension/alby-hub/liquidity/increase-receiving-capacity"
+                >
+                  increase your receiving capacity.
+                </ExternalLink>
+              </AlertDescription>
+            </Alert>
+          )}
+
+          {/* If all channels have less or equal balance than their reserve, show a warning */}
+          {channels?.every(
+            (channel) =>
+              channel.localBalance <=
+              channel.unspendablePunishmentReserve * 1000
+          ) && (
+            <Alert>
+              <AlertTriangle className="h-4 w-4" />
+              <AlertTitle>Channel reserves unmet</AlertTitle>
+              <AlertDescription>
+                You won't be able to make payments until you{" "}
+                <ExternalLink
+                  className="underline"
+                  to="https://guides.getalby.com/user-guide/v/alby-account-and-browser-extension/alby-hub/liquidity/increase-spending-balance"
+                >
+                  increase your spending balance.
+                </ExternalLink>
+              </AlertDescription>
+            </Alert>
+          )}
+        </>
+      )}
+
       <div
         className={cn(
           "grid grid-cols-1 gap-3",
@@ -568,6 +620,7 @@ export default function Channels() {
                     <div>Receiving</div>
                   </div>
                 </TableHead>
+                <TableHead className="w-[24px]"></TableHead>
                 <TableHead className="w-[50px]"></TableHead>
               </TableRow>
             </TableHeader>
@@ -581,6 +634,16 @@ export default function Channels() {
                     const alias = node?.alias || "Unknown";
                     const capacity =
                       channel.localBalance + channel.remoteBalance;
+
+                    let channelWarning = "";
+                    if (channel.localSpendableBalance < capacity * 0.1) {
+                      channelWarning =
+                        "Sending balance low. You may have trouble sending payments through this channel.";
+                    }
+                    if (channel.localSpendableBalance > capacity * 0.9) {
+                      channelWarning =
+                        "Receiving capacity low. You may have trouble receiving payments through this channel.";
+                    }
 
                     return (
                       <TableRow key={channel.id}>
@@ -612,6 +675,18 @@ export default function Channels() {
                         <TableCell
                           title={channel.unspendablePunishmentReserve + " sats"}
                         >
+                          {channel.localBalance <
+                            channel.unspendablePunishmentReserve * 1000 && (
+                            <>
+                              {formatAmount(
+                                Math.min(
+                                  channel.localBalance,
+                                  channel.unspendablePunishmentReserve * 1000
+                                )
+                              )}{" "}
+                              /{" "}
+                            </>
+                          )}
                           {formatAmount(
                             channel.unspendablePunishmentReserve * 1000
                           )}{" "}
@@ -620,14 +695,19 @@ export default function Channels() {
                         <TableCell>
                           <div className="relative">
                             <Progress
-                              value={(channel.localBalance / capacity) * 100}
+                              value={
+                                (channel.localSpendableBalance / capacity) * 100
+                              }
                               className="h-6 absolute"
                             />
                             <div className="flex flex-row w-full justify-between px-2 text-xs items-center h-6 mix-blend-exclusion text-white">
                               <span
-                                title={channel.localBalance / 1000 + " sats"}
+                                title={
+                                  channel.localSpendableBalance / 1000 + " sats"
+                                }
                               >
-                                {formatAmount(channel.localBalance)} sats
+                                {formatAmount(channel.localSpendableBalance)}{" "}
+                                sats
                               </span>
                               <span
                                 title={channel.remoteBalance / 1000 + " sats"}
@@ -636,6 +716,20 @@ export default function Channels() {
                               </span>
                             </div>
                           </div>
+                        </TableCell>
+                        <TableCell>
+                          {channelWarning ? (
+                            <TooltipProvider>
+                              <Tooltip>
+                                <TooltipTrigger>
+                                  <AlertTriangle className="w-4 h-4 mt-1" />
+                                </TooltipTrigger>
+                                <TooltipContent className="w-[400px]">
+                                  {channelWarning}
+                                </TooltipContent>
+                              </Tooltip>
+                            </TooltipProvider>
+                          ) : null}
                         </TableCell>
                         <TableCell>
                           <DropdownMenu>

--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -380,12 +380,9 @@ export default function Channels() {
               <AlertTitle>Low receiving capacity</AlertTitle>
               <AlertDescription>
                 You likely won't be able to receive payments until you{" "}
-                <ExternalLink
-                  className="underline"
-                  to="https://guides.getalby.com/user-guide/v/alby-account-and-browser-extension/alby-hub/liquidity/increase-receiving-capacity"
-                >
+                <Link className="underline" to="/channels/incoming">
                   increase your receiving capacity.
-                </ExternalLink>
+                </Link>
               </AlertDescription>
             </Alert>
           )}
@@ -401,12 +398,9 @@ export default function Channels() {
               <AlertTitle>Channel reserves unmet</AlertTitle>
               <AlertDescription>
                 You won't be able to make payments until you{" "}
-                <ExternalLink
-                  className="underline"
-                  to="https://guides.getalby.com/user-guide/v/alby-account-and-browser-extension/alby-hub/liquidity/increase-spending-balance"
-                >
+                <Link className="underline" to="/channels/outgoing">
                   increase your spending balance.
-                </ExternalLink>
+                </Link>
               </AlertDescription>
             </Alert>
           )}
@@ -645,7 +639,7 @@ export default function Channels() {
                       let channelWarning = "";
                       if (channel.localSpendableBalance < capacity * 0.1) {
                         channelWarning =
-                          "Sending balance low. You may have trouble sending payments through this channel.";
+                          "Spending balance low. You may have trouble sending payments through this channel.";
                       }
                       if (channel.localSpendableBalance > capacity * 0.9) {
                         channelWarning =

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -166,6 +166,7 @@ export interface CreateAppResponse {
 
 export type Channel = {
   localBalance: number;
+  localSpendableBalance: number;
   remoteBalance: number;
   remotePubkey: string;
   id: string;

--- a/lnclient/greenlight/greenlight.go
+++ b/lnclient/greenlight/greenlight.go
@@ -379,12 +379,13 @@ func (gs *GreenlightService) ListChannels(ctx context.Context) ([]lnclient.Chann
 		}
 
 		channels = append(channels, lnclient.Channel{
-			LocalBalance:  int64(localAmount),
-			RemoteBalance: int64(totalAmount - localAmount),
-			RemotePubkey:  glChannel.PeerId,
-			Id:            *glChannel.ChannelId,
-			Active:        glChannel.State == 2,
-			FundingTxId:   glChannel.FundingTxid,
+			LocalBalance:          int64(localAmount),
+			LocalSpendableBalance: int64(localAmount),
+			RemoteBalance:         int64(totalAmount - localAmount),
+			RemotePubkey:          glChannel.PeerId,
+			Id:                    *glChannel.ChannelId,
+			Active:                glChannel.State == 2,
+			FundingTxId:           glChannel.FundingTxid,
 			// TODO: add Public property
 		})
 	}

--- a/lnclient/ldk/ldk.go
+++ b/lnclient/ldk/ldk.go
@@ -798,7 +798,8 @@ func (ls *LDKService) ListChannels(ctx context.Context) ([]lnclient.Channel, err
 
 		channels = append(channels, lnclient.Channel{
 			InternalChannel:                          internalChannel,
-			LocalBalance:                             int64(ldkChannel.OutboundCapacityMsat),
+			LocalBalance:                             int64(ldkChannel.ChannelValueSats*1000 - ldkChannel.InboundCapacityMsat - ldkChannel.CounterpartyUnspendablePunishmentReserve*1000),
+			LocalSpendableBalance:                    int64(ldkChannel.OutboundCapacityMsat),
 			RemoteBalance:                            int64(ldkChannel.InboundCapacityMsat),
 			RemotePubkey:                             ldkChannel.CounterpartyNodeId,
 			Id:                                       ldkChannel.UserChannelId, // CloseChannel takes the UserChannelId

--- a/lnclient/lnd/lnd.go
+++ b/lnclient/lnd/lnd.go
@@ -201,6 +201,7 @@ func (svc *LNDService) ListChannels(ctx context.Context) ([]lnclient.Channel, er
 		channels[i] = lnclient.Channel{
 			InternalChannel:                          lndChannel,
 			LocalBalance:                             lndChannel.LocalBalance * 1000,
+			LocalSpendableBalance:                    (lndChannel.LocalBalance - int64(lndChannel.LocalConstraints.ChanReserveSat)) * 1000,
 			RemoteBalance:                            lndChannel.RemoteBalance * 1000,
 			RemotePubkey:                             lndChannel.RemotePubkey,
 			Id:                                       strconv.FormatUint(lndChannel.ChanId, 10),

--- a/lnclient/models.go
+++ b/lnclient/models.go
@@ -75,6 +75,7 @@ type LNClient interface {
 
 type Channel struct {
 	LocalBalance                             int64       `json:"localBalance"`
+	LocalSpendableBalance                    int64       `json:"localSpendableBalance"`
 	RemoteBalance                            int64       `json:"remoteBalance"`
 	Id                                       string      `json:"id"`
 	RemotePubkey                             string      `json:"remotePubkey"`


### PR DESCRIPTION
This PR adds alerts to the liquidity page when something needs to be reviewed by the user so they understand why payments might be failing.

No UI changes when your channels are healthy.

- fix: LDK local balance not including amount in reserve
- show current reserve amount if unmet
- unmet channel reserve alert
- low receiving capacity alert
- unbalanced channel warnings
- fix: new channel order sidebar hint not showing on liquidity page

![image](https://github.com/getAlby/nostr-wallet-connect-next/assets/33993199/57bf3893-c172-4bdd-b673-0ff71a18ebf3)

![image](https://github.com/getAlby/nostr-wallet-connect-next/assets/33993199/c992e7a5-2535-4921-a465-facaf2cda43b)

![image](https://github.com/getAlby/nostr-wallet-connect-next/assets/33993199/830f5a5e-0160-4b8f-b2cf-229b7069785a)

![image](https://github.com/getAlby/nostr-wallet-connect-next/assets/33993199/2802bcaf-88be-4023-8a3e-6f59042f67ee)
