### PR TITLE
chore: create bz2 archives in http build

### DIFF
--- a/.github/workflows/http.yml
+++ b/.github/workflows/http.yml
@@ -118,11 +118,11 @@ jobs:
       - name: Make output tar archive to keep file permissions
         run: |
           mkdir -p ./build/out
-          tar czf ./build/out/${{ env.PACKAGE_NAME }}.tar.gz -C ./build/bin/${{ env.PACKAGE_NAME }} .
+          tar -cjf ./build/out/${{ env.PACKAGE_NAME }}.tar.bz2 -C ./build/bin/${{ env.PACKAGE_NAME }} .
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.PACKAGE_NAME }}.tar.gz
+          name: ${{ env.PACKAGE_NAME }}.tar.bz2
           path: |
-            ./build/out/${{ env.PACKAGE_NAME }}.tar.gz
+            ./build/out/${{ env.PACKAGE_NAME }}.tar.bz2
           if-no-files-found: error


### PR DESCRIPTION
to keep it always the same and bz2 is smaller than gz