### PR TITLE
fix: use Go version from go.mod in Github actions

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version-file: './go.mod'
       - name: Run tests
         run: mkdir frontend/dist && touch frontend/dist/tmp && go test ./...
       - name: Docker build

--- a/.github/workflows/http.yml
+++ b/.github/workflows/http.yml
@@ -46,8 +46,7 @@ jobs:
       - name: Setup GoLang
         uses: actions/setup-go@v5
         with:
-          check-latest: true
-          go-version: 1.21
+          go-version-file: './go.mod'
 
       - name: Get dependencies
         run: go get -v -t -d ./...

--- a/.github/workflows/wails.yml
+++ b/.github/workflows/wails.yml
@@ -50,8 +50,7 @@ jobs:
       - name: Setup GoLang
         uses: actions/setup-go@v5
         with:
-          check-latest: true
-          go-version: 1.21
+          go-version-file: './go.mod'
 
       - name: Get dependencies
         run: go get -v -t -d ./...

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/getAlby/nostr-wallet-connect
 
 go 1.22.2
 
-toolchain go1.22.3
-
 require (
 	github.com/adrg/xdg v0.4.0
 	github.com/breez/breez-sdk-go v0.3.4


### PR DESCRIPTION
This is intended to ensure consistency of Go versions in go.mod and in Github actions and releases, as well as to fix tar warnings originating from the setup-go action:

```
Failed to restore: "/usr/bin/tar" failed with error: The process '/usr/bin/tar' failed with exit code 2
```

The workaround, as suggested by https://github.com/actions/setup-go/issues/424, is to use exactly the same version of Go in the Github actions as the one specified in go.mod.

Additionally, this PR removes the `toolchain` directive from go.mod as unneeded (and it also causes the tar error mentioned above)