### PR TITLE
feat: configurable update URL

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -588,6 +588,7 @@ func (api *api) GetInfo(ctx context.Context) (*InfoResponse, error) {
 	info.OAuthRedirect = !api.cfg.GetEnv().IsDefaultClientId()
 	info.Version = version.Tag
 	info.LatestVersion = version.GetLatestReleaseTag()
+	info.UpdateUrl = api.cfg.GetEnv().UpdateUrl
 	albyUserIdentifier, err := api.albyOAuthSvc.GetUserIdentifier()
 	if err != nil {
 		logger.Logger.WithError(err).Error("Failed to get alby user identifier")

--- a/api/models.go
+++ b/api/models.go
@@ -155,6 +155,7 @@ type InfoResponse struct {
 	Version              string `json:"version"`
 	LatestVersion        string `json:"latestVersion"`
 	Network              string `json:"network"`
+	UpdateUrl            string `json:"updateUrl"`
 }
 
 type EncryptedMnemonicResponse struct {

--- a/config/models.go
+++ b/config/models.go
@@ -40,6 +40,7 @@ type AppConfig struct {
 	PhoenixdAuthorization string `envconfig:"PHOENIXD_AUTHORIZATION"`
 	GoProfilerAddr        string `envconfig:"GO_PROFILER_ADDR"`
 	DdProfilerEnabled     bool   `envconfig:"DD_PROFILER_ENABLED" default:"false"`
+	UpdateUrl             string `envconfig:"UPDATE_URL" default:"https://guides.getalby.com/user-guide/v/alby-account-and-browser-extension/alby-hub/updating-your-hub"`
 }
 
 func (c *AppConfig) IsDefaultClientId() bool {

--- a/frontend/src/components/layouts/AppLayout.tsx
+++ b/frontend/src/components/layouts/AppLayout.tsx
@@ -206,32 +206,34 @@ export default function AppLayout() {
                       <span className="">Alby Hub</span>
                     </Link>
 
-                    <TooltipProvider>
-                      <Tooltip>
-                        <TooltipTrigger>
-                          <ExternalLink
-                            to="https://getalby.com/hub_deployment/edit" // TODO: link to general update page
-                            className="font-semibold text-xl"
-                          >
-                            <span className="text-xs flex items-center text-muted-foreground">
-                              {info?.version}&nbsp;
-                              {upToDate ? (
-                                <ShieldCheckIcon className="w-4 h-4" />
-                              ) : (
-                                <ShieldAlertIcon className="w-4 h-4" />
-                              )}
-                            </span>
-                          </ExternalLink>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          {upToDate ? (
-                            <p>Alby Hub is up to date!</p>
-                          ) : (
-                            <p>Alby Hub {info?.latestVersion} available!</p>
-                          )}
-                        </TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
+                    {info && (
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger>
+                            <ExternalLink
+                              to={info.updateUrl}
+                              className="font-semibold text-xl"
+                            >
+                              <span className="text-xs flex items-center text-muted-foreground">
+                                {info.version}&nbsp;
+                                {upToDate ? (
+                                  <ShieldCheckIcon className="w-4 h-4" />
+                                ) : (
+                                  <ShieldAlertIcon className="w-4 h-4" />
+                                )}
+                              </span>
+                            </ExternalLink>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            {upToDate ? (
+                              <p>Alby Hub is up to date!</p>
+                            ) : (
+                              <p>Alby Hub {info.latestVersion} available!</p>
+                            )}
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    )}
                   </div>
                   <MainMenuContent />
                 </nav>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -148,6 +148,7 @@ export interface InfoResponse {
   network?: Network;
   version: string;
   latestVersion: string;
+  updateUrl: string;
 }
 
 export type Network = "bitcoin" | "testnet" | "signet";


### PR DESCRIPTION
Now defaults to the Alby guide where we can add guides for all the Alby Hub flavors.
- [ ] pass current version as query parameter when linking to update page