### PR TITLE
chore: push card footer to bottom

### DIFF
--- a/frontend/src/screens/channels/Channels.tsx
+++ b/frontend/src/screens/channels/Channels.tsx
@@ -414,14 +414,14 @@ export default function Channels() {
         )}
       >
         {showHostedBalance && (
-          <Card>
+          <Card className="flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">
                 Alby Hosted Balance
               </CardTitle>
               <Hotel className="h-4 w-4 text-muted-foreground" />
             </CardHeader>
-            <CardContent>
+            <CardContent className="flex-grow">
               <div className="text-2xl font-bold">
                 {new Intl.NumberFormat().format(albyBalance?.sats)} sats
               </div>
@@ -476,14 +476,14 @@ export default function Channels() {
             </CardFooter>
           </Card>
         )}
-        <Card>
+        <Card className="flex flex-col">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">
               Savings Balance
             </CardTitle>
             <Bitcoin className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
-          <CardContent>
+          <CardContent className="flex-grow">
             {!balances && (
               <div>
                 <div className="animate-pulse d-inline ">
@@ -519,14 +519,14 @@ export default function Channels() {
             </Link>
           </CardFooter>
         </Card>
-        <Card>
+        <Card className="flex flex-col">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">
               Spending Balance
             </CardTitle>
             <ArrowUp className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
-          <CardContent>
+          <CardContent className="flex-grow">
             {!balances && (
               <div>
                 <div className="animate-pulse d-inline ">
@@ -549,14 +549,14 @@ export default function Channels() {
             </Link>
           </CardFooter>
         </Card>
-        <Card>
+        <Card className="flex flex-col">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">
               Receiving Capacity
             </CardTitle>
             <ArrowDown className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
-          <CardContent>
+          <CardContent className="flex-grow">
             <div className="text-2xl font-bold">
               {balances &&
                 new Intl.NumberFormat().format(


### PR DESCRIPTION
## Note

`mb-5` is just added to keep the sats in other cards in the same line as Savings Balance sats, if this feels hacky, we can group Header and Content in a div and add `flex flex-col justify-between` to the `<Card>`

## Before
<img width="100%" alt="Screenshot 2024-07-03 at 10 40 02 AM" src="https://github.com/getAlby/nostr-wallet-connect-next/assets/64399555/991bad64-44c6-42c7-acd0-c3a78f636d6b">

## After
<img width="100%" alt="Screenshot 2024-07-03 at 10 39 44 AM" src="https://github.com/getAlby/nostr-wallet-connect-next/assets/64399555/7f749cc7-65a1-42c2-9ad4-6ed44bb9983c">
